### PR TITLE
Adding missing patches to openSUSE-2017.7.2

### DIFF
--- a/openSUSE-2017.7.2/bugfix-the-logic-according-to-the-exact-described-pu.patch
+++ b/openSUSE-2017.7.2/bugfix-the-logic-according-to-the-exact-described-pu.patch
@@ -1,0 +1,316 @@
+From 0e1cac43dd8211186d6794602f6da77f612850a7 Mon Sep 17 00:00:00 2001
+From: Bo Maryniuk <bo@suse.de>
+Date: Tue, 21 Nov 2017 12:53:11 +0100
+Subject: [PATCH] Bugfix the logic according to the exact described
+ purpose of the function.
+
+Rename function from ambiguous name
+
+Fix and clarify docstring.
+
+Remove unused variable (no exception, within the try/finally block)
+
+Bugfix: do not pull '_errors' from unchecked objects
+
+Bugfix: unit test mistakenly expects pillar errors as a string, while it is a list
+
+Fix unit test: wrong error types in side effect
+
+Add unit test for _get_pillar_errors when external and internal pillars are clean
+
+Add unit test for _get_pillar_errors when external pillar has errors and internal is clean
+
+Add unit test for _get_pillar_errors when both external and internal pillars contains errors
+
+Add unit test for _get_pillar_errors when external pillar is clean and internal contains errors
+
+Use variable, instead of direct value
+---
+ salt/modules/state.py            | 82 +++++++++++++++++++---------------------
+ tests/unit/modules/test_state.py | 75 +++++++++++++++++++++++++++++++-----
+ 2 files changed, 103 insertions(+), 54 deletions(-)
+
+diff --git a/salt/modules/state.py b/salt/modules/state.py
+index fa5b997ef7..31ffc25dfe 100644
+--- a/salt/modules/state.py
++++ b/salt/modules/state.py
+@@ -99,17 +99,16 @@ def _set_retcode(ret, highstate=None):
+         __context__['retcode'] = 2
+ 
+ 
+-def _check_pillar(kwargs, pillar=None):
++def _get_pillar_errors(kwargs, pillar=None):
+     '''
+-    Check the pillar for errors, refuse to run the state if there are errors
+-    in the pillar and return the pillar errors
++    Checks all pillars (external and internal) for errors.
++    Return an error message, if anywhere or None.
++
++    :param kwargs: dictionary of options
++    :param pillar: external pillar
++    :return: None or an error message
+     '''
+-    if kwargs.get('force'):
+-        return True
+-    pillar_dict = pillar if pillar is not None else __pillar__
+-    if '_errors' in pillar_dict:
+-        return False
+-    return True
++    return None if kwargs.get('force') else (pillar or {}).get('_errors', __pillar__.get('_errors')) or None
+ 
+ 
+ def _wait(jid):
+@@ -411,10 +410,10 @@ def template(tem, queue=False, **kwargs):
+                                context=__context__,
+                                initial_pillar=_get_initial_pillar(opts))
+ 
+-    if not _check_pillar(kwargs, st_.opts['pillar']):
++    errors = _get_pillar_errors(kwargs, pillar=st_.opts['pillar'])
++    if errors:
+         __context__['retcode'] = 5
+-        raise CommandExecutionError('Pillar failed to render',
+-                                    info=st_.opts['pillar']['_errors'])
++        raise CommandExecutionError('Pillar failed to render', info=errors)
+ 
+     if not tem.endswith('.sls'):
+         tem = '{sls}.sls'.format(sls=tem)
+@@ -872,11 +871,10 @@ def highstate(test=None, queue=False, **kwargs):
+                                    mocked=kwargs.get('mock', False),
+                                    initial_pillar=_get_initial_pillar(opts))
+ 
+-    if not _check_pillar(kwargs, st_.opts['pillar']):
++    errors = _get_pillar_errors(kwargs, st_.opts['pillar'])
++    if errors:
+         __context__['retcode'] = 5
+-        err = ['Pillar failed to render with the following messages:']
+-        err += __pillar__['_errors']
+-        return err
++        return ['Pillar failed to render with the following messages:'] + errors
+ 
+     st_.push_active()
+     ret = {}
+@@ -1071,11 +1069,10 @@ def sls(mods, test=None, exclude=None, queue=False, **kwargs):
+                                    mocked=kwargs.get('mock', False),
+                                    initial_pillar=_get_initial_pillar(opts))
+ 
+-    if not _check_pillar(kwargs, st_.opts['pillar']):
++    errors = _get_pillar_errors(kwargs, pillar=st_.opts['pillar'])
++    if errors:
+         __context__['retcode'] = 5
+-        err = ['Pillar failed to render with the following messages:']
+-        err += __pillar__['_errors']
+-        return err
++        return ['Pillar failed to render with the following messages:'] + errors
+ 
+     orchestration_jid = kwargs.get('orchestration_jid')
+     umask = os.umask(0o77)
+@@ -1090,7 +1087,6 @@ def sls(mods, test=None, exclude=None, queue=False, **kwargs):
+         mods = mods.split(',')
+ 
+     st_.push_active()
+-    ret = {}
+     try:
+         high_, errors = st_.render_highstate({opts['environment']: mods})
+ 
+@@ -1197,11 +1193,10 @@ def top(topfn, test=None, queue=False, **kwargs):
+                                pillar_enc=pillar_enc,
+                                context=__context__,
+                                initial_pillar=_get_initial_pillar(opts))
+-    if not _check_pillar(kwargs, st_.opts['pillar']):
++    errors = _get_pillar_errors(kwargs, pillar=st_.opts['pillar'])
++    if errors:
+         __context__['retcode'] = 5
+-        err = ['Pillar failed to render with the following messages:']
+-        err += __pillar__['_errors']
+-        return err
++        return ['Pillar failed to render with the following messages:'] + errors
+ 
+     st_.push_active()
+     st_.opts['state_top'] = salt.utils.url.create(topfn)
+@@ -1259,10 +1254,10 @@ def show_highstate(queue=False, **kwargs):
+                                pillar_enc=pillar_enc,
+                                initial_pillar=_get_initial_pillar(opts))
+ 
+-    if not _check_pillar(kwargs, st_.opts['pillar']):
++    errors = _get_pillar_errors(kwargs, pillar=st_.opts['pillar'])
++    if errors:
+         __context__['retcode'] = 5
+-        raise CommandExecutionError('Pillar failed to render',
+-                                    info=st_.opts['pillar']['_errors'])
++        raise CommandExecutionError('Pillar failed to render', info=errors)
+ 
+     st_.push_active()
+     try:
+@@ -1293,10 +1288,10 @@ def show_lowstate(queue=False, **kwargs):
+     st_ = salt.state.HighState(opts,
+                                initial_pillar=_get_initial_pillar(opts))
+ 
+-    if not _check_pillar(kwargs, st_.opts['pillar']):
++    errors = _get_pillar_errors(kwargs, pillar=st_.opts['pillar'])
++    if errors:
+         __context__['retcode'] = 5
+-        raise CommandExecutionError('Pillar failed to render',
+-                                    info=st_.opts['pillar']['_errors'])
++        raise CommandExecutionError('Pillar failed to render', info=errors)
+ 
+     st_.push_active()
+     try:
+@@ -1394,11 +1389,10 @@ def sls_id(id_, mods, test=None, queue=False, **kwargs):
+         st_ = salt.state.HighState(opts,
+                                    initial_pillar=_get_initial_pillar(opts))
+ 
+-    if not _check_pillar(kwargs, st_.opts['pillar']):
++    errors = _get_pillar_errors(kwargs, pillar=st_.opts['pillar'])
++    if errors:
+         __context__['retcode'] = 5
+-        err = ['Pillar failed to render with the following messages:']
+-        err += __pillar__['_errors']
+-        return err
++        return ['Pillar failed to render with the following messages:'] + errors
+ 
+     if isinstance(mods, six.string_types):
+         split_mods = mods.split(',')
+@@ -1474,10 +1468,10 @@ def show_low_sls(mods, test=None, queue=False, **kwargs):
+ 
+     st_ = salt.state.HighState(opts, initial_pillar=_get_initial_pillar(opts))
+ 
+-    if not _check_pillar(kwargs, st_.opts['pillar']):
++    errors = _get_pillar_errors(kwargs, pillar=st_.opts['pillar'])
++    if errors:
+         __context__['retcode'] = 5
+-        raise CommandExecutionError('Pillar failed to render',
+-                                    info=st_.opts['pillar']['_errors'])
++        raise CommandExecutionError('Pillar failed to render', info=errors)
+ 
+     if isinstance(mods, six.string_types):
+         mods = mods.split(',')
+@@ -1561,10 +1555,10 @@ def show_sls(mods, test=None, queue=False, **kwargs):
+                                pillar_enc=pillar_enc,
+                                initial_pillar=_get_initial_pillar(opts))
+ 
+-    if not _check_pillar(kwargs, st_.opts['pillar']):
++    errors = _get_pillar_errors(kwargs, pillar=st_.opts['pillar'])
++    if errors:
+         __context__['retcode'] = 5
+-        raise CommandExecutionError('Pillar failed to render',
+-                                    info=st_.opts['pillar']['_errors'])
++        raise CommandExecutionError('Pillar failed to render', info=errors)
+ 
+     if isinstance(mods, six.string_types):
+         mods = mods.split(',')
+@@ -1610,10 +1604,10 @@ def show_top(queue=False, **kwargs):
+ 
+     st_ = salt.state.HighState(opts, initial_pillar=_get_initial_pillar(opts))
+ 
+-    if not _check_pillar(kwargs, st_.opts['pillar']):
++    errors = _get_pillar_errors(kwargs, pillar=st_.opts['pillar'])
++    if errors:
+         __context__['retcode'] = 5
+-        raise CommandExecutionError('Pillar failed to render',
+-                                    info=st_.opts['pillar']['_errors'])
++        raise CommandExecutionError('Pillar failed to render', info=errors)
+ 
+     errors = []
+     top_ = st_.get_top()
+diff --git a/tests/unit/modules/test_state.py b/tests/unit/modules/test_state.py
+index 7f4f361c26..e5d10493da 100644
+--- a/tests/unit/modules/test_state.py
++++ b/tests/unit/modules/test_state.py
+@@ -695,9 +695,9 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
+         with patch.object(state, '_check_queue', mock):
+             self.assertEqual(state.top("reverse_top.sls"), "A")
+ 
+-            mock = MagicMock(side_effect=[False, True, True])
+-            with patch.object(state, '_check_pillar', mock):
+-                with patch.dict(state.__pillar__, {"_errors": "E"}):
++            mock = MagicMock(side_effect=[['E'], None, None])
++            with patch.object(state, '_get_pillar_errors', mock):
++                with patch.dict(state.__pillar__, {"_errors": ['E']}):
+                     self.assertListEqual(state.top("reverse_top.sls"), ret)
+ 
+                 with patch.dict(state.__opts__, {"test": "A"}):
+@@ -854,14 +854,10 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
+                                                True),
+                                      ["A"])
+ 
+-                mock = MagicMock(side_effect=[False,
+-                                              True,
+-                                              True,
+-                                              True,
+-                                              True])
+-                with patch.object(state, '_check_pillar', mock):
++                mock = MagicMock(side_effect=[['E', '1'], None, None, None, None])
++                with patch.object(state, '_get_pillar_errors', mock):
+                     with patch.dict(state.__context__, {"retcode": 5}):
+-                        with patch.dict(state.__pillar__, {"_errors": "E1"}):
++                        with patch.dict(state.__pillar__, {"_errors": ['E', '1']}):
+                             self.assertListEqual(state.sls("core,edit.vim dev",
+                                                            None,
+                                                            None,
+@@ -979,3 +975,62 @@ class StateTestCase(TestCase, LoaderModuleMockMixin):
+                 with patch('salt.utils.fopen', mock_open()):
+                     self.assertTrue(state.pkg("/tmp/state_pkg.tgz",
+                                               0, "md5"))
++
++    def test_get_pillar_errors_CC(self):
++        '''
++        Test _get_pillar_errors function.
++        CC: External clean, Internal clean
++        :return:
++        '''
++        for int_pillar, ext_pillar in [({'foo': 'bar'}, {'fred': 'baz'}),
++                                       ({'foo': 'bar'}, None),
++                                       ({}, {'fred': 'baz'})]:
++            with patch('salt.modules.state.__pillar__', int_pillar):
++                for opts, res in [({'force': True}, None),
++                                  ({'force': False}, None),
++                                  ({}, None)]:
++                    assert res == state._get_pillar_errors(kwargs=opts, pillar=ext_pillar)
++
++    def test_get_pillar_errors_EC(self):
++        '''
++        Test _get_pillar_errors function.
++        EC: External erroneous, Internal clean
++        :return:
++        '''
++        errors = ['failure', 'everywhere']
++        for int_pillar, ext_pillar in [({'foo': 'bar'}, {'fred': 'baz', '_errors': errors}),
++                                       ({}, {'fred': 'baz', '_errors': errors})]:
++            with patch('salt.modules.state.__pillar__', int_pillar):
++                for opts, res in [({'force': True}, None),
++                                  ({'force': False}, errors),
++                                  ({}, errors)]:
++                    assert res == state._get_pillar_errors(kwargs=opts, pillar=ext_pillar)
++
++    def test_get_pillar_errors_EE(self):
++        '''
++        Test _get_pillar_errors function.
++        CC: External erroneous, Internal erroneous
++        :return:
++        '''
++        errors = ['failure', 'everywhere']
++        for int_pillar, ext_pillar in [({'foo': 'bar', '_errors': errors}, {'fred': 'baz', '_errors': errors})]:
++            with patch('salt.modules.state.__pillar__', int_pillar):
++                for opts, res in [({'force': True}, None),
++                                  ({'force': False}, errors),
++                                  ({}, errors)]:
++                    assert res == state._get_pillar_errors(kwargs=opts, pillar=ext_pillar)
++
++    def test_get_pillar_errors_CE(self):
++        '''
++        Test _get_pillar_errors function.
++        CC: External clean, Internal erroneous
++        :return:
++        '''
++        errors = ['failure', 'everywhere']
++        for int_pillar, ext_pillar in [({'foo': 'bar', '_errors': errors}, {'fred': 'baz'}),
++                                       ({'foo': 'bar', '_errors': errors}, None)]:
++            with patch('salt.modules.state.__pillar__', int_pillar):
++                for opts, res in [({'force': True}, None),
++                                  ({'force': False}, errors),
++                                  ({}, errors)]:
++                    assert res == state._get_pillar_errors(kwargs=opts, pillar=ext_pillar)
+-- 
+2.15.1
+
+

--- a/openSUSE-2017.7.2/return-error-when-gid_from_name-and-group-does-not-e.patch
+++ b/openSUSE-2017.7.2/return-error-when-gid_from_name-and-group-does-not-e.patch
@@ -1,0 +1,123 @@
+From 5384cb815764af43f287bcb6ed49a9a68d5cd5c0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pablo=20Su=C3=A1rez=20Hern=C3=A1ndez?=
+ <psuarezhernandez@suse.com>
+Date: Wed, 10 Jan 2018 11:59:33 +0000
+Subject: [PATCH] Return error when gid_from_name and group does not
+ exist.
+
+Fixes #45345
+
+Ensure empty string gid is set to None
+
+Make pylint happy
+
+Fix integration tests for 'user.present' state.
+
+Update documentation for 'gid_from_name' parameter
+
+Refactor to prevent logical bug when gid is 0
+---
+ salt/states/user.py                   |  7 +++++-
+ tests/integration/states/test_user.py | 42 +++++++++++++++++++++++------------
+ 2 files changed, 34 insertions(+), 15 deletions(-)
+
+diff --git a/salt/states/user.py b/salt/states/user.py
+index 8a731cc2a1..737c39f4b4 100644
+--- a/salt/states/user.py
++++ b/salt/states/user.py
+@@ -240,7 +240,8 @@ def present(name,
+ 
+     gid_from_name
+         If True, the default group id will be set to the id of the group with
+-        the same name as the user, Default is ``False``.
++        the same name as the user. If the group does not exist the state will
++        fail. Default is ``False``.
+ 
+     groups
+         A list of groups to assign the user to, pass a list object. If a group
+@@ -455,6 +456,10 @@ def present(name,
+ 
+     if gid_from_name:
+         gid = __salt__['file.group_to_gid'](name)
++        if gid == '':
++            ret['comment'] = 'Default group with name "{0}" is not present'.format(name)
++            ret['result'] = False
++            return ret
+ 
+     changes = _changes(name,
+                        uid,
+diff --git a/tests/integration/states/test_user.py b/tests/integration/states/test_user.py
+index 1317f12f97..ae9774a241 100644
+--- a/tests/integration/states/test_user.py
++++ b/tests/integration/states/test_user.py
+@@ -97,15 +97,25 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
+                              home=HOMEDIR)
+         self.assertSaltTrueReturn(ret)
+ 
+-    def test_user_present_nondefault(self):
++    @requires_system_grains
++    def test_user_present_nondefault(self, grains=None):
+         '''
+         This is a DESTRUCTIVE TEST it creates a new user on the on the minion.
+         '''
+         ret = self.run_state('user.present', name=self.user_name,
+                              home=self.user_home)
+         self.assertSaltTrueReturn(ret)
++        ret = self.run_function('user.info', [self.user_name])
++        self.assertReturnNonEmptySaltType(ret)
++        group_name = grp.getgrgid(ret['gid']).gr_name
+         if not salt.utils.is_darwin():
+             self.assertTrue(os.path.isdir(self.user_home))
++        if grains['os_family'] in ('Suse',):
++            self.assertEqual(group_name, 'users')
++        elif grains['os_family'] == 'MacOS':
++            self.assertEqual(group_name, 'staff')
++        else:
++            self.assertEqual(group_name, self.user_name)
+ 
+     @requires_system_grains
+     def test_user_present_gid_from_name_default(self, grains=None):
+@@ -120,22 +130,26 @@ class UserTest(ModuleCase, SaltReturnAssertsMixin):
+         # user
+         gid_from_name = False if grains['os_family'] == 'MacOS' else True
+ 
+-        ret = self.run_state('user.present', name=self.user_name,
++        ret_user_present = self.run_state('user.present', name=self.user_name,
+                              gid_from_name=gid_from_name, home=self.user_home)
+-        self.assertSaltTrueReturn(ret)
+ 
+-        ret = self.run_function('user.info', [self.user_name])
+-        self.assertReturnNonEmptySaltType(ret)
+-        group_name = grp.getgrgid(ret['gid']).gr_name
+-
+-        if not salt.utils.is_darwin():
+-            self.assertTrue(os.path.isdir(self.user_home))
+-        if grains['os_family'] in ('Suse',):
+-            self.assertEqual(group_name, 'users')
+-        elif grains['os_family'] == 'MacOS':
+-            self.assertEqual(group_name, 'staff')
++        if gid_from_name:
++            self.assertSaltFalseReturn(ret_user_present)
++            ret_user_present = ret_user_present[next(iter(ret_user_present))]
++            self.assertTrue('is not present' in ret_user_present['comment'])
+         else:
+-            self.assertEqual(group_name, self.user_name)
++            self.assertSaltTrueReturn(ret_user_present)
++            ret_user_info = self.run_function('user.info', [self.user_name])
++            self.assertReturnNonEmptySaltType(ret_user_info)
++            group_name = grp.getgrgid(ret_user_info['gid']).gr_name
++            if not salt.utils.is_darwin():
++                self.assertTrue(os.path.isdir(self.user_home))
++            if grains['os_family'] in ('Suse',):
++                self.assertEqual(group_name, 'users')
++            elif grains['os_family'] == 'MacOS':
++                self.assertEqual(group_name, 'staff')
++            else:
++                self.assertEqual(group_name, self.user_name)
+ 
+     def test_user_present_gid_from_name(self):
+         '''
+-- 
+2.15.1
+
+

--- a/openSUSE-2017.7.2/salt.spec
+++ b/openSUSE-2017.7.2/salt.spec
@@ -70,6 +70,8 @@ Patch19:       python3-compatibility-fix-got-bytes-instead-of-strin.patch
 Patch20:       feat-add-grain-for-all-fqdns.patch
 Patch21:       fix-bsc-1065792.patch
 Patch22:       set-shell-environment-variable-64.patch
+Patch23:       bugfix-the-logic-according-to-the-exact-described-pu.patch
+Patch24:       return-error-when-gid_from_name-and-group-does-not-e.patch
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  logrotate
@@ -429,6 +431,8 @@ cp %{S:5} ./.travis.yml
 %patch20 -p1
 %patch21 -p1
 %patch22 -p1
+%patch23 -p1
+%patch24 -p1
 
 %build
 %{__python3} setup.py --with-salt-version=%{version} --salt-transport=both build


### PR DESCRIPTION
- Bugfix: errors in external pillar causes crash instead of report of them (bsc#1068446)
- Fix 'user.present' when 'gid_from_name' is set but group does not exist.

- Added:
 * bugfix-the-logic-according-to-the-exact-described-pu.patch
 * return-error-when-gid_from_name-and-group-does-not-e.patch