### PR TITLE
fix usage of macros

### DIFF
--- a/openSUSE-2017.7.2/salt.spec
+++ b/openSUSE-2017.7.2/salt.spec
@@ -25,12 +25,9 @@
 # SLE12
 %global build_py3   1
 %global build_py2   1
-%global default_py3 0
 %else
 # RES7
-%global build_py3   0
 %global build_py2   1
-%global default_py3 0
 %endif
 %endif
 %define pythonX %{?default_py3: python3}%{!?default_py3: python2}


### PR DESCRIPTION
In the spec we are checking if a macro is "defined". Setting it to "0" is also "defined".
Instead of setting it to 0 we must not define it at all.