### PR TITLE
Prevent queryformat pattern from expanding

### DIFF
--- a/openSUSE-2017.7.2/salt.spec
+++ b/openSUSE-2017.7.2/salt.spec
@@ -904,7 +904,7 @@ if [ $1 -eq 2 ] ; then
   true
 fi
 %if %{with systemd}
-if [ `rpm -q systemd --queryformat="%{VERSION}"` -lt 228 ]; then
+if [ `rpm -q systemd --queryformat="%%{VERSION}"` -lt 228 ]; then
   # On systemd < 228 the 'TasksTask' attribute is not available.
   # Removing TasksMax from salt-master.service on SLE12SP1 LTSS (bsc#985112)
   sed -i '/TasksMax=infinity/d' %{_unitdir}/salt-master.service


### PR DESCRIPTION
ref: https://bugzilla.suse.com/show_bug.cgi?id=1079048

```bash
(3/4) Installing: salt-master-2017.7.2-320.50.1.develHead.x86_64 ......................................................................................................................................................................[done]
Additional rpm output:
/usr/src/packages/tmp/rpm-tmp.dQUKBi: line 15: [: 2017.7.2: integer expression expected
```