### PR TITLE
fixes for salt-ssh

### DIFF
--- a/salt/extra-filerefs-include-files-even-if-no-refs-in-stat.patch
+++ b/salt/extra-filerefs-include-files-even-if-no-refs-in-stat.patch
@@ -1,0 +1,32 @@
+From 544dfd7dbaa1c837b75976f15ad67159b1bdedbb Mon Sep 17 00:00:00 2001
+From: Matei Albu <malbu@suse.de>
+Date: Sun, 6 May 2018 11:56:18 +0200
+Subject: [PATCH] --extra-filerefs include files even if no refs in
+ states to apply
+
+Fixes #47496
+(cherry picked from commit d67239a)
+---
+ salt/client/ssh/state.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/salt/client/ssh/state.py b/salt/client/ssh/state.py
+index 8fa11d031e..08d4846bb6 100644
+--- a/salt/client/ssh/state.py
++++ b/salt/client/ssh/state.py
+@@ -135,9 +135,9 @@ def lowstate_file_refs(chunks, extras=''):
+             elif state.startswith('__'):
+                 continue
+             crefs.extend(salt_refs(chunk[state]))
++        if saltenv not in refs:
++            refs[saltenv] = []
+         if crefs:
+-            if saltenv not in refs:
+-                refs[saltenv] = []
+             refs[saltenv].append(crefs)
+     if extras:
+         extra_refs = extras.split(',')
+-- 
+2.13.6
+
+

--- a/salt/option-to-merge-current-pillar-with-opts-pillar-duri.patch
+++ b/salt/option-to-merge-current-pillar-with-opts-pillar-duri.patch
@@ -1,0 +1,101 @@
+From 0cfa4f2a1cf559f87286069691a2766cb24f6076 Mon Sep 17 00:00:00 2001
+From: Matei Albu <malbu@suse.de>
+Date: Sun, 6 May 2018 21:15:58 +0200
+Subject: [PATCH] Option to merge current pillar with opts['pillar']
+ during pillar compile
+
+Fixes #47501
+(cherry picked from commit 2f1485e)
+---
+ doc/ref/configuration/minion.rst | 28 ++++++++++++++++++++++++++++
+ salt/config/__init__.py          |  4 +++-
+ salt/pillar/__init__.py          |  7 +++++++
+ 3 files changed, 38 insertions(+), 1 deletion(-)
+
+diff --git a/doc/ref/configuration/minion.rst b/doc/ref/configuration/minion.rst
+index 9683a0a20a..75ad26c723 100644
+--- a/doc/ref/configuration/minion.rst
++++ b/doc/ref/configuration/minion.rst
+@@ -3219,3 +3219,31 @@ URL of the repository:
+ Replace ``<commit_id>`` with the SHA1 hash of a commit ID. Specifying a commit
+ ID is useful in that it allows one to revert back to a previous version in the
+ event that an error is introduced in the latest revision of the repo.
++
++``ssh_merge_pillar``
++--------------------
++
++.. versionadded:: 2018.3.2
++
++Default: ``True``
++
++Merges the compiled pillar data with the pillar data already available globally.
++This is useful when using ``salt-ssh`` or ``salt-call --local`` and overriding the pillar
++data in a state file:
++
++.. code-block:: yaml
++
++    apply_showpillar:
++      module.run:
++        - name: state.apply
++        - mods:
++          - showpillar
++        - kwargs:
++              pillar:
++                  test: "foo bar"
++
++If set to ``True`` the ``showpillar`` state will have access to the
++global pillar data.
++
++If set to ``False`` only the overriding pillar data will be available
++to the ``showpillar`` state.
+diff --git a/salt/config/__init__.py b/salt/config/__init__.py
+index b3de3820b0..82d3dfa07f 100644
+--- a/salt/config/__init__.py
++++ b/salt/config/__init__.py
+@@ -983,6 +983,7 @@ VALID_OPTS = {
+     'ssh_identities_only': bool,
+     'ssh_log_file': six.string_types,
+     'ssh_config_file': six.string_types,
++    'ssh_merge_pillar': bool,
+ 
+     # Enable ioflo verbose logging. Warning! Very verbose!
+     'ioflo_verbose': int,
+@@ -1476,6 +1477,7 @@ DEFAULT_MINION_OPTS = {
+     },
+     'discovery': False,
+     'schedule': {},
++    'ssh_merge_pillar': True
+ }
+ 
+ DEFAULT_MASTER_OPTS = {
+@@ -2078,7 +2080,7 @@ def _validate_ssh_minion_opts(opts):
+ 
+     for opt_name in list(ssh_minion_opts):
+         if re.match('^[a-z0-9]+fs_', opt_name, flags=re.IGNORECASE) \
+-                or 'pillar' in opt_name \
++                or ('pillar' in opt_name and not 'ssh_merge_pillar' == opt_name) \
+                 or opt_name in ('fileserver_backend',):
+             log.warning(
+                 '\'%s\' is not a valid ssh_minion_opts parameter, ignoring',
+diff --git a/salt/pillar/__init__.py b/salt/pillar/__init__.py
+index 388b774434..5940b7c105 100644
+--- a/salt/pillar/__init__.py
++++ b/salt/pillar/__init__.py
+@@ -993,6 +993,13 @@ class Pillar(object):
+             mopts['file_roots'] = self.actual_file_roots
+             mopts['saltversion'] = __version__
+             pillar['master'] = mopts
++        if 'pillar' in self.opts and self.opts.get('ssh_merge_pillar', False):
++            pillar = merge(
++                self.opts['pillar'],
++                pillar,
++                self.merge_strategy,
++                self.opts.get('renderer', 'yaml'),
++                self.opts.get('pillar_merge_lists', False))
+         if errors:
+             for error in errors:
+                 log.critical('Pillar render error: %s', error)
+-- 
+2.13.6
+
+

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -98,7 +98,10 @@ Patch18:       provide-kwargs-to-pkg_resource.parse_targets-require.patch
 Patch19:       initialize-__context__-retcode-for-functions-handled.patch
 # PATCH-FIX_UPSTREAM https://github.com/saltstack/salt/pull/47232
 Patch20:       fixed-usage-of-ipaddress.patch
-
+# PATCH-FIX_UPSTREAM https://github.com/saltstack/salt/pull/47497
+Patch21:       extra-filerefs-include-files-even-if-no-refs-in-stat.patch
+# PATCH-FIX_UPSTREAM https://github.com/saltstack/salt/pull/47504
+Patch22:       option-to-merge-current-pillar-with-opts-pillar-duri.patch
 
 # BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -577,6 +580,8 @@ cp %{S:5} ./.travis.yml
 %patch18 -p1
 %patch19 -p1
 %patch20 -p1
+%patch21 -p1
+%patch22 -p1
 
 %build
 %if 0%{?build_py2}


### PR DESCRIPTION
Patches from upstream:
    - `--extra-filerefs` doesn't add all files to the state archive (PR saltstack/salt#47497)
    - pillar completely overwritten (not merged) when doing `module.run` + `state.apply` with pillar in `kwargs` (PR saltstack/salt#47504)