### PR TITLE
Multiversion patch plus upstream fix

### DIFF
--- a/salt/fix-for-sorting-of-multi-version-packages-bsc-109717.patch
+++ b/salt/fix-for-sorting-of-multi-version-packages-bsc-109717.patch
@@ -1,0 +1,35 @@
+From ba9191b1c60508a8348bc1a9bfca0d06ad1fad34 Mon Sep 17 00:00:00 2001
+From: Jochen Breuer <jbreuer@suse.de>
+Date: Wed, 13 Jun 2018 17:51:13 +0200
+Subject: [PATCH] Fix for sorting of multi-version packages (bsc#1097174
+ and bsc#1097413)
+
+---
+ salt/modules/rpm.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/salt/modules/rpm.py b/salt/modules/rpm.py
+index 3683234f59..8e71992f81 100644
+--- a/salt/modules/rpm.py
++++ b/salt/modules/rpm.py
+@@ -9,6 +9,7 @@ import logging
+ import os
+ import re
+ import datetime
++from distutils.version import LooseVersion
+ 
+ # Import Salt libs
+ import salt.utils.decorators.path
+@@ -609,7 +610,7 @@ def info(*packages, **kwargs):
+     # pick only latest versions
+     # (in case multiple packages installed, e.g. kernel)
+     ret = dict()
+-    for pkg_data in reversed(sorted(_ret, key=lambda x: x['edition'])):
++    for pkg_data in reversed(sorted(_ret, key=lambda x: LooseVersion(x['edition']))):
+         pkg_name = pkg_data.pop('name')
+         # Filter out GPG public keys packages
+         if pkg_name.startswith('gpg-pubkey'):
+-- 
+2.13.7
+
+

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -120,6 +120,10 @@ Patch29:       align-suse-salt-master.service-limitnofiles-limit-wi.patch
 Patch30:       fix-deprecation-warning-bsc-1095507.patch
 # PATCH-FIX_OPENSUSE bsc#1057635
 Patch31:       add-environment-variable-to-know-if-yum-is-invoked-f.patch
+# PATCH-FIX_OPENSUSE bsc#1097174 and bsc#1097413
+Patch32:       fix-for-sorting-of-multi-version-packages-bsc-109717.patch
+# PATCH-FIX_OPENSUSE bsc#1098072
+Patch33:       switching-looseversion-import-to-salt.utils.versions.patch
 
 # BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -609,6 +613,8 @@ cp %{S:5} ./.travis.yml
 %patch29 -p1
 %patch30 -p1
 %patch31 -p1
+%patch32 -p1
+%patch33 -p1
 
 %build
 %if 0%{?build_py2}

--- a/salt/switching-looseversion-import-to-salt.utils.versions.patch
+++ b/salt/switching-looseversion-import-to-salt.utils.versions.patch
@@ -1,0 +1,27 @@
+From 3e9dec25173051a1743a7da64cd6176a15874b8d Mon Sep 17 00:00:00 2001
+From: Jochen Breuer <jbreuer@suse.de>
+Date: Fri, 15 Jun 2018 13:06:16 +0200
+Subject: [PATCH] Switching LooseVersion import to salt.utils.versions
+ (bsc#1098072)
+
+---
+ salt/modules/rpm.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/salt/modules/rpm.py b/salt/modules/rpm.py
+index 8e71992f81..15738b2523 100644
+--- a/salt/modules/rpm.py
++++ b/salt/modules/rpm.py
+@@ -9,7 +9,7 @@ import logging
+ import os
+ import re
+ import datetime
+-from distutils.version import LooseVersion
++from salt.utils.versions import LooseVersion
+ 
+ # Import Salt libs
+ import salt.utils.decorators.path
+-- 
+2.13.7
+
+


### PR DESCRIPTION
Patches need to be reordered to reflect the changes in products. Since the
multiversion patch hat to be pushed to products directly, we have to change
this for products:testing now.