### PR TITLE
 Conflict with tornado >= 5

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -323,6 +323,8 @@ BuildRequires:  python-msgpack-python > 0.3
 BuildRequires:  python-psutil
 BuildRequires:  python-requests >= 1.0.0
 BuildRequires:  python-tornado >= 4.2.1
+# We can't cope with tornado 5.x and newer (boo#1101780)
+BuildConflicts: python3-tornado >= 5
 
 # requirements/zeromq.txt
 BuildRequires:  python-pycrypto >= 2.6.1
@@ -365,6 +367,8 @@ Requires:       python-msgpack-python > 0.3
 Requires:       python-psutil
 Requires:       python-requests >= 1.0.0
 Requires:       python-tornado >= 4.2.1
+# We can't cope with tornado 5.x and newer (boo#1101780)
+Conflicts: python3-tornado >= 5
 %if 0%{?suse_version}
 # required for zypper.py
 Requires:       rpm-python
@@ -411,6 +415,8 @@ BuildRequires:  python3-msgpack-python > 0.3
 BuildRequires:  python3-psutil
 BuildRequires:  python3-requests >= 1.0.0
 BuildRequires:  python3-tornado >= 4.2.1
+# We can't cope with tornado 5.x and newer (boo#1101780)
+BuildConflicts: python3-tornado >= 5
 
 # requirements/zeromq.txt
 BuildRequires:  python3-pycrypto >= 2.6.1
@@ -449,6 +455,8 @@ Requires:       python3-msgpack-python > 0.3
 Requires:       python3-psutil
 Requires:       python3-requests >= 1.0.0
 Requires:       python3-tornado >= 4.2.1
+# We can't cope with tornado 5.x and newer (boo#1101780)
+Conflicts: python3-tornado >= 5
 %if 0%{?suse_version}
 # required for zypper.py
 Requires:       python3-rpm


### PR DESCRIPTION
 for now we can only cope with Tornado 4.x (boo#1101780).

Source: https://build.opensuse.org/request/show/723933