### PR TITLE
Prefer to take version.py from python3

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -803,7 +803,9 @@ cp %{S:5} ./.travis.yml
 %build
 %if 0%{?build_py2}
 %{__python} setup.py --with-salt-version=%{version} --salt-transport=both build
+%if ! 0%{?build_py3}
 cp ./build/lib/salt/_version.py ./salt
+%endif
 mv build _build.python2
 %endif
 %if 0%{?build_py3}


### PR DESCRIPTION
Prefer to take version.py from python3
to avoid randomness from readdir order to make build reproducible

See https://reproducible-builds.org/ for why this is good.

Without this patch, there would randomly occur such variations:
```diff
+++ new//usr/lib/python2.7/site-packages/salt/_version.py       2019-09-05 12:00:00.000000000 +0000
_version.py
-__saltstack_version__ = SaltStackVersion(2018, 1, 99, 0, '', 0, 0, None)
+__saltstack_version__ = SaltStackVersion(2018, 1, 99, 0, u'', 0, 0, None)
```

from setup.py
```python
            open(self.distribution.salt_version_hardcoded_path, 'w').write(
                INSTALL_VERSION_TEMPLATE.format(
                    date=DATE,
                    full_version_info=salt_version.full_info
                )
            )
```

setup.py is run with python2 and 3 in random filesystem order