### PR TITLE
Build: Buildequire pkgconfig(systemd) instead of systemd

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -369,8 +369,8 @@ Requires:       iproute
 %endif
 
 %if %{with systemd}
-BuildRequires:  systemd
-%{?systemd_requires}
+BuildRequires:  pkgconfig(systemd)
+%{?systemd_ordering}
 %else
 %if 0%{?suse_version}
 Requires(pre): %insserv_prereq


### PR DESCRIPTION
pkgconfig(systemd) is provided by systemd, so this is de-facto no change.
But inside the Open Build Service (OBS), the same symbol is also provided by
systemd-mini, which exists to shorten build-chains by only enabling what other
packages need to successfully build