### PR TITLE
Enable building and installation for Fedora

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -38,7 +38,7 @@
 %endif
 %define pythonX %{?default_py3: python3}%{!?default_py3: python2}
 
-%if 0%{?suse_version} > 1210 || 0%{?rhel} >= 7 || 0%{?fedora}
+%if 0%{?suse_version} > 1210 || 0%{?rhel} >= 7 || 0%{?fedora} >=28
 %bcond_without systemd
 %else
 %bcond_with    systemd
@@ -355,7 +355,7 @@ BuildRequires:  bash
 BuildRequires:  zsh
 %endif
 
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?fedora}
 BuildRequires:  yum
 %endif
 
@@ -376,7 +376,7 @@ BuildRequires:  python >= 2.7
 BuildRequires:  python-devel >= 2.7
 BuildRequires:  python-setuptools
 # requirements/base.txt
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?fedora}
 BuildRequires:  python-jinja2
 BuildRequires:  python-yaml
 BuildRequires:  python-markupsafe
@@ -418,7 +418,7 @@ Requires:       python >= 2.7
 Requires:       python-certifi
 %endif
 # requirements/base.txt
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?fedora}
 Requires:       python-jinja2
 Requires:       python-yaml
 Requires:       python-markupsafe
@@ -481,7 +481,7 @@ BuildRequires:  python3
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 # requirements/base.txt
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?fedora}
 BuildRequires:  python3-jinja2
 BuildRequires:  python3-markupsafe
 BuildRequires:  python3-msgpack > 0.3
@@ -527,14 +527,14 @@ Requires:       python3
 Requires:       python3-certifi
 %endif
 # requirements/base.txt
-%if 0%{?rhel}
+%if 0%{?rhel} || 0%{?fedora}
 Requires:       python3-jinja2
 Requires:       yum
 Requires:       python3-markupsafe
 Requires:       python3-msgpack > 0.3
 Requires:       python3-m2crypto
 Requires:       python3-zmq >= 2.2.0
-%if 0%{?rhel} == 8
+%if 0%{?rhel} == 8 || 0%{?fedora} >= 30
 Requires:       dnf
 %endif
 %if 0%{?rhel} == 6


### PR DESCRIPTION
Port of changes at https://build.opensuse.org/package/view_file/home:ethanb11:Fedora_Uyuni:Master:Fedora30-Uyuni-Client-Tools/salt/salt.spec?expand=1 (https://github.com/openSUSE/salt-packaging/pull/28), for salt 3000

Reference: https://github.com/uyuni-project/uyuni/issues/2085