### PR TITLE
Require /usr/bin/python instead of /bin/python (bsc#1173936)

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -1030,6 +1030,12 @@ cp %{S:5} ./.travis.yml
 %patch141 -p1
 
 %build
+# Putting /usr/bin at the front of $PATH is needed for RHEL/RES 7. Without this
+# change, the RPM will require /bin/python, which is not provided by any package
+# on RHEL/RES 7.
+%if 0%{?fedora} || 0%{?rhel}
+export PATH=/usr/bin:$PATH
+%endif
 %if 0%{?build_py2}
 python setup.py --with-salt-version=%{version} --salt-transport=both build
 cp ./build/lib/salt/_version.py ./salt


### PR DESCRIPTION
I went for a PR for this one because I changed the specfile slightly from the [osc specfile](https://build.opensuse.org/package/view_file/openSUSE:Tools/osc/osc.spec?expand=1). As far as I can tell from building Salt locally, exporting PATH instead of changing it inline twice works and does not have a negative effect. But please take a look / double check that this is indeed the case.
