### PR TITLE
Fix systemd version checking (bsc#1176294)

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -1375,7 +1375,7 @@ if [ $1 -eq 2 ] ; then
   true
 fi
 %if %{with systemd}
-if [ `rpm -q systemd --queryformat="%%{VERSION}"` -lt 228 ]; then
+if [ $(rpm -q systemd --queryformat="%%{VERSION}" | sed 's/\..*//') -lt 228 ]; then
   # On systemd < 228 the 'TasksTask' attribute is not available.
   # Removing TasksMax from salt-master.service on SLE12SP1 LTSS (bsc#985112)
   sed -i '/TasksMax=infinity/d' %{_unitdir}/salt-master.service


### PR DESCRIPTION
`rpm -q systemd --queryformat="%{VERSION}"` returns version with dots which can't be compared as an integer in shell script