### PR TITLE
3000.3: change 'Requires(pre)' to 'Requires' for salt-minion package (bsc#1083110)

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -745,7 +745,7 @@ than serially.
 %package minion
 Summary:        The client component for Saltstack
 Group:          System/Management
-Requires(pre):  %{name} = %{version}-%{release}
+Requires:       %{name} = %{version}-%{release}
 
 %if %{with systemd}
 %{?systemd_requires}


### PR DESCRIPTION
Fixes https://github.com/SUSE/spacewalk/issues/13116
The only difference `Requires(pre)` allows to remove `salt` package while keeps `salt-minion` installed.
`Requires` prevents removing `salt` package while `salt-minion` is installed.