### PR TITLE
Always require python-certifi (used by salt.ext.tornado)

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -535,10 +535,7 @@ BuildRequires:  python-xml
 BuildRequires:  python-sphinx
 %endif
 Requires:       python >= 2.7
-#
-%if ! 0%{?suse_version} > 1110
 Requires:       python-certifi
-%endif
 # requirements/base.txt
 %if 0%{?rhel} || 0%{?fedora}
 Requires:       python-jinja2
@@ -647,10 +644,7 @@ Requires:       platform-python
 %else
 Requires:       python3
 %endif
-#
-%if ! 0%{?suse_version} > 1110
 Requires:       python3-certifi
-%endif
 # requirements/base.txt
 %if 0%{?rhel} || 0%{?fedora}
 Requires:       python3-jinja2


### PR DESCRIPTION
I checked the specfile and there is no other mention of `%if ! ...` which does not seem to work as expected. I was not able to find out why the condition did not resolve to `true` for CentOS, but since `python-certifi` is pulled in via `python-requests` (a hard dependency of this spec), I think there is no harm in dropping the condition completely.

Fixes https://github.com/uyuni-project/uyuni/issues/3144