### PR TITLE
Exclude SLE 12 from requiring python-certifi

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -552,7 +552,9 @@ BuildRequires:  python-xml
 BuildRequires:  python-sphinx
 %endif
 Requires:       python >= 2.7
+%if 0%{?suse_version} >= 1500 || 0%{?rhel}
 Requires:       python-certifi
+%endif
 # requirements/base.txt
 %if 0%{?rhel} || 0%{?fedora}
 Requires:       python-jinja2


### PR DESCRIPTION
I have not tested this yet, but it should require `python-certifi` for SLE/Leap 15 (which still build python2-salt) and RHEL/CentOS7. It is only SLE 12 that does not require it anymore.