### PR TITLE
Convert Requires to Recommends for salt-transactional-update

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -697,7 +697,7 @@ Summary:        The client component for Saltstack
 Group:          System/Management
 Requires:       %{name} = %{version}-%{release}
 %if 0%{?suse_version} > 1500 || 0%{?sle_version} > 150000
-Requires:       (%{name}-transactional-update = %{version}-%{release} if read-only-root-fs)
+Recommends:     (%{name}-transactional-update = %{version}-%{release} if read-only-root-fs)
 %endif
 
 %if %{with systemd}


### PR DESCRIPTION
The configuration file inside the package makes always the
transactional-update executor to be called.  This is a way to work
with transactional systems as transparent as is possible, but make it
complicate when the user needs to execute some actions inside the
transaction and others outside.

The current executor always map the calls like "state.apply" or
"state.highstate" inside the executor, so to opt-out the user needs to
aggregate all the actions in a module (or change the logic of the
executor to do more complicated mappings)

This patch makes this configuration as an opt-in decision, as in
MicroOS the recommended packages are not installed by default.