### PR TITLE
minion on transactional-update server requires tar

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -856,6 +856,7 @@ Summary:        Transactional update executor configuration
 Group:          System/Management
 Requires:       %{name} = %{version}-%{release}
 Requires:       %{name}-minion = %{version}-%{release}
+Requires:       tar
 
 %description transactional-update
 For transactional systems, like MicroOS, Salt can operate


### PR DESCRIPTION
Found on openSUSE Leap 15.3, where `tar` is not installed by default on a transactional server.

Without this fix, trying to apply a state on a minion running on such a system results in this error:

```
master:~ # salt luftnetz state.apply profile.grains
luftnetz:
    ERROR: Unable to run command '['tar', 'xzf', '/var/cache/salt/minion/thin/thin.tgz', '-C', '/var/cache/salt/minion/tmpnpbrg0nn']' with the context '{'cwd': '/root', 'shell': False, 'env': {'LANG': 'en_US.UTF-8', 'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', 'NOTIFY_SOCKET': '/run/systemd/notify', 'INVOCATION_ID': 'd7139a0a333e47b180027cbde7c20856', 'JOURNAL_STREAM': '9:27262', 'LC_CTYPE': 'C', 'LC_NUMERIC': 'C', 'LC_TIME': 'C', 'LC_COLLATE': 'C', 'LC_MONETARY': 'C', 'LC_MESSAGES': 'C', 'LC_PAPER': 'C', 'LC_NAME': 'C', 'LC_ADDRESS': 'C', 'LC_TELEPHONE': 'C', 'LC_MEASUREMENT': 'C', 'LC_IDENTIFICATION': 'C', 'LANGUAGE': 'C'}, 'stdin': None, 'stdout': -1, 'stderr': -2, 'with_communicate': True, 'timeout': None, 'bg': False, 'close_fds': True}', reason: [Errno 2] No such file or directory: 'tar': 'tar'
```