### PR TITLE
Remove redundant overrides causing confusing DEBUG logging (bsc#1189501)

### DIFF
--- a/salt/remove-redundand-overrides-causing-confusing-debug-l.patch
+++ b/salt/remove-redundand-overrides-causing-confusing-debug-l.patch
@@ -1,0 +1,101 @@
+From 58eb1db2ccdde1aa9cdaae9b33051446b3351f54 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Yeray=20Guti=C3=A9rrez=20Cedr=C3=A9s?=
+ <yeray.gutierrez@suse.com>
+Date: Mon, 9 May 2022 13:44:31 +0100
+Subject: [PATCH] Remove redundand overrides causing confusing DEBUG
+ log (bsc#1189501)
+
+---
+ salt/_compat.py | 74 -------------------------------------------------
+ 1 file changed, 74 deletions(-)
+
+diff --git a/salt/_compat.py b/salt/_compat.py
+index 22daaa31a0..ecd42e5f75 100644
+--- a/salt/_compat.py
++++ b/salt/_compat.py
+@@ -231,81 +231,7 @@ class IPv6InterfaceScoped(ipaddress.IPv6Interface, IPv6AddressScoped):
+         self.hostmask = self.network.hostmask
+ 
+ 
+-def ip_address(address):
+-    """Take an IP string/int and return an object of the correct type.
+-
+-    Args:
+-        address: A string or integer, the IP address.  Either IPv4 or
+-          IPv6 addresses may be supplied; integers less than 2**32 will
+-          be considered to be IPv4 by default.
+-
+-    Returns:
+-        An IPv4Address or IPv6Address object.
+-
+-    Raises:
+-        ValueError: if the *address* passed isn't either a v4 or a v6
+-          address
+-
+-    """
+-    try:
+-        return ipaddress.IPv4Address(address)
+-    except (ipaddress.AddressValueError, ipaddress.NetmaskValueError) as err:
+-        log.debug('Error while parsing IPv4 address: %s', address)
+-        log.debug(err)
+-
+-    try:
+-        return IPv6AddressScoped(address)
+-    except (ipaddress.AddressValueError, ipaddress.NetmaskValueError) as err:
+-        log.debug('Error while parsing IPv6 address: %s', address)
+-        log.debug(err)
+-
+-    if isinstance(address, bytes):
+-        raise ipaddress.AddressValueError('{} does not appear to be an IPv4 or IPv6 address. '
+-                                          'Did you pass in a bytes (str in Python 2) instead '
+-                                          'of a unicode object?'.format(repr(address)))
+-
+-    raise ValueError('{} does not appear to be an IPv4 or IPv6 address'.format(repr(address)))
+-
+-
+-def ip_interface(address):
+-    """Take an IP string/int and return an object of the correct type.
+-
+-    Args:
+-        address: A string or integer, the IP address.  Either IPv4 or
+-          IPv6 addresses may be supplied; integers less than 2**32 will
+-          be considered to be IPv4 by default.
+-
+-    Returns:
+-        An IPv4Interface or IPv6Interface object.
+-
+-    Raises:
+-        ValueError: if the string passed isn't either a v4 or a v6
+-          address.
+-
+-    Notes:
+-        The IPv?Interface classes describe an Address on a particular
+-        Network, so they're basically a combination of both the Address
+-        and Network classes.
+-
+-    """
+-    try:
+-        return ipaddress.IPv4Interface(address)
+-    except (ipaddress.AddressValueError, ipaddress.NetmaskValueError) as err:
+-        log.debug('Error while getting IPv4 interface for address %s', address)
+-        log.debug(err)
+-
+-    try:
+-        return ipaddress.IPv6Interface(address)
+-    except (ipaddress.AddressValueError, ipaddress.NetmaskValueError) as err:
+-        log.debug('Error while getting IPv6 interface for address %s', address)
+-        log.debug(err)
+-
+-    raise ValueError('{} does not appear to be an IPv4 or IPv6 interface'.format(address))
+-
+-
+ if ipaddress:
+     ipaddress.IPv6Address = IPv6AddressScoped
+     if sys.version_info.major == 2:
+         ipaddress.IPv6Interface = IPv6InterfaceScoped
+-    ipaddress.ip_address = ip_address
+-    ipaddress.ip_interface = ip_interface
+-- 
+2.35.1
+
+

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -538,6 +538,8 @@ Patch214:       vendor-stateresult.patch
 Patch215:       fix-possible-traceback-on-ip6_interface-grain-bsc-11.patch
 # PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/61530
 Patch216:       fix-inspector-module-export-function-bsc-1097531-479.patch
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/50962
+Patch217:       remove-redundand-overrides-causing-confusing-debug-l.patch
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  logrotate
@@ -1300,6 +1302,7 @@ cp %{S:6} .
 %patch214 -p1
 %patch215 -p1
 %patch216 -p1
+%patch217 -p1
 
 %build
 # Putting /usr/bin at the front of $PATH is needed for RHEL/RES 7. Without this


### PR DESCRIPTION
This patch removes redundant overrides for ip_address/ip_interface causing confusing DEBUG logging when there are IPv6 interfaces present (bsc#1189501)
https://github.com/openSUSE/salt/pull/512