### PR TITLE
Enable multibuilld and create test flavor

### DIFF
--- a/salt/_multibuild
+++ b/salt/_multibuild
@@ -1,0 +1,3 @@
+<multibuild>
+  <flavor>test</flavor>
+</multibuild>

--- a/salt/_multibuild
+++ b/salt/_multibuild
@@ -1,3 +1,3 @@
 <multibuild>
-  <flavor>test</flavor>
+  <flavor>testsuite_included</flavor>
 </multibuild>

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -700,7 +700,7 @@ Requires(pre):  %fillup_prereq
 Salt ssh is a master running without zmq.
 it enables the management of minions over a ssh connection.
 
-%if "%{flavor}" == "test"
+%if "%{flavor}" == "testsuite_included"
 %package -n python3-salt-testsuite
 Summary:        Unit and integration tests for Salt
 Requires:       %{name} = %{version}-%{release}
@@ -874,7 +874,7 @@ install -Dd -m 0755 %{buildroot}%{_sysconfdir}/logrotate.d/
 # Install salt-support profiles
 install -Dpm 0644 salt/cli/support/profiles/* %{buildroot}%{python3_sitelib}/salt/cli/support/profiles
 
-%if "%{flavor}" == "test"
+%if "%{flavor}" == "testsuite_included"
 # Install Salt tests
 install -Dd %{buildroot}%{python3_sitelib}/salt-testsuite
 cp -a tests %{buildroot}%{python3_sitelib}/salt-testsuite/
@@ -1471,7 +1471,7 @@ rm -f %{_localstatedir}/cache/salt/minion/thin/version
 %doc doc/_build/html
 %endif
 
-%if "%{flavor}" == "test"
+%if "%{flavor}" == "testsuite_included"
 %files -n python3-salt-testsuite
 %{python3_sitelib}/salt-testsuite
 %endif

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -15,6 +15,7 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 %global debug_package %{nil}
+%global flavor @BUILD_FLAVOR@%{nil}
 
 %if 0%{?suse_version} > 1210 || 0%{?rhel} >= 7 || 0%{?fedora} >=28
 %bcond_without systemd
@@ -699,6 +700,7 @@ Requires(pre):  %fillup_prereq
 Salt ssh is a master running without zmq.
 it enables the management of minions over a ssh connection.
 
+%if "%{flavor}" == "test"
 %package -n python3-salt-testsuite
 Summary:        Unit and integration tests for Salt
 Requires:       %{name} = %{version}-%{release}
@@ -725,6 +727,7 @@ Obsoletes:      %{name}-tests
 
 %description -n python3-salt-testsuite
 Collection of unit, functional, and integration tests for %{name}.
+%endif
 
 %if %{with bash_completion}
 %package bash-completion
@@ -871,6 +874,7 @@ install -Dd -m 0755 %{buildroot}%{_sysconfdir}/logrotate.d/
 # Install salt-support profiles
 install -Dpm 0644 salt/cli/support/profiles/* %{buildroot}%{python3_sitelib}/salt/cli/support/profiles
 
+%if "%{flavor}" == "test"
 # Install Salt tests
 install -Dd %{buildroot}%{python3_sitelib}/salt-testsuite
 cp -a tests %{buildroot}%{python3_sitelib}/salt-testsuite/
@@ -878,6 +882,7 @@ cp -a tests %{buildroot}%{python3_sitelib}/salt-testsuite/
 rm %{buildroot}%{python3_sitelib}/salt-testsuite/tests/runtests.py
 # Copy conf files to the testsuite as they are used by the tests
 cp -a conf %{buildroot}%{python3_sitelib}/salt-testsuite/
+%endif
 
 ## Install Zypper plugins only on SUSE machines
 %if 0%{?suse_version}
@@ -1466,8 +1471,10 @@ rm -f %{_localstatedir}/cache/salt/minion/thin/version
 %doc doc/_build/html
 %endif
 
+%if "%{flavor}" == "test"
 %files -n python3-salt-testsuite
 %{python3_sitelib}/salt-testsuite
+%endif
 
 %if %{with bash_completion}
 %files bash-completion

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -462,7 +462,7 @@ BuildRequires:  python3-packaging
 # requirements/zeromq.txt
 %if %{with test}
 BuildRequires:  python3-boto >= 2.32.1
-BuildRequires:  python3-mock
+BuildRequires:  %{python3-mock if %python-base < 3.8}
 BuildRequires:  python3-moto >= 0.3.6
 BuildRequires:  python3-pip
 BuildRequires:  python3-salt-testing >= 2015.2.16
@@ -710,7 +710,9 @@ Requires:       python3-boto
 %endif
 Requires:       python3-boto3
 Requires:       python3-docker
+%if 0%{?suse_version} < 1600
 Requires:       python3-mock
+%endif
 Requires:       python3-pygit2
 Requires:       python3-pytest >= 7.0.1
 Requires:       python3-pytest-httpserver


### PR DESCRIPTION
With this PR we enable `multibuild` in order to create a repository that includes the `python3-salt-testsuite` package and another repository without this `python3-salt-testsuite` package  so we can submit it to `openSUSE:Factory` without having to include more dependencies to Ring 1.


Also, in the context of pushing `python3-salt-testsuite` to Factory and since the submission of  `python-mock` was rejected, we need to disable this dependency. An alternative strategy was followed, favouring the use of `unittest.mock` for newer Python versions. See this [PR](https://github.com/openSUSE/salt/pull/612). 