### PR TITLE
Provide user(salt) and group(salt) on openSUSE Tumbleweed

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -358,6 +358,11 @@ Obsoletes:      python2-%{name}
 Requires(pre):  %{_sbindir}/groupadd
 Requires(pre):  %{_sbindir}/useradd
 
+%if 0%{?suse_version} > 1600
+Provides:       group(salt)
+Provides:       user(salt)
+%endif
+
 %if 0%{?suse_version}
 Requires(pre):  %fillup_prereq
 Requires(pre):  shadow


### PR DESCRIPTION
With RPM 4.19, whenever a package installs files as specific user, explicit dependency on those users are being added. This package takes care of creating the user in its pre script.

More details: https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/HG2JKUIKDTWQQIQSA43A4VWHX7YKJQT3/