### PR TITLE
Improve Salt and testsuite packages multibuild

### DIFF
--- a/salt/_multibuild
+++ b/salt/_multibuild
@@ -1,3 +1,3 @@
 <multibuild>
-  <flavor>testsuite_included</flavor>
+  <flavor>testsuite</flavor>
 </multibuild>


### PR DESCRIPTION
Multibuild is not valid at this moment as the test flavor produces a complete set of binaries. This PR fixes multibuild with the `testsuite` flavor not building all RPMs.

Also the `%check` section is removed as running the test suite during the build is not intended.