### PR TITLE
Fix Salt dependency for testsuite package

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -796,7 +796,7 @@ BuildRequires:  python3
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 
-Requires:       %{name} = %{version}-%{release}
+Requires:       salt = %{version}-%{release}
 Requires:       python3-CherryPy
 Requires:       python3-Genshi
 Requires:       python3-Mako


### PR DESCRIPTION
At this moment `python3-salt-testsuite` is requiring `salt-test` instead of `salt` so we need to fix it.