### PR TITLE
Do not require Salt release tag for testsuite

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -800,7 +800,7 @@ BuildRequires:  python3
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 
-Requires:       salt = %{version}-%{release}
+Requires:       salt = %{version}
 Requires:       python3-CherryPy
 Requires:       python3-Genshi
 Requires:       python3-Mako


### PR DESCRIPTION
%release contains a build counter which, with the test suite being its own separate build, is not guaranteed to by in sync

A drawback for this might be that if both `salt` and `python3-salt-testsuite` are updated (so for example there's a new test that tests a new functionality) and a user does `zypper up python3-salt-testsuite` he won't be receiving the last build of Salt (as the requirement is just the version). 

However, this would mean that the user did not follow best practice of `zypper dup` for maintainers.

The `#!BCntSyncTag: salt` in the spec file could be used to force sync but that would mean a higher load on the scheduler and maybe not a great benefit. 