### PR TITLE
[skip] Fix SLE12 build failure

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -920,6 +920,8 @@ install -Dpm 0644 salt/cli/support/profiles/* %{buildroot}%{python3_sitelib}/sal
 %if "%{flavor}" == "testsuite"
 # Install Salt tests
 install -Dd %{buildroot}%{python3_sitelib}/salt-testsuite
+# SLE 12 is missing the `--no-backup-if-mismatch` patch option
+find tests -name "*.orig" -exec rm {} \;
 cp -a tests %{buildroot}%{python3_sitelib}/salt-testsuite/
 # Remove runtests.py which is not used as deprecated method of running the tests
 rm %{buildroot}%{python3_sitelib}/salt-testsuite/tests/runtests.py


### PR DESCRIPTION
On SLE 12, the `patch` command currently creates two `.orig` files that fail the RPM build:

```
tests/pytests/unit/fileserver/test_roots.py.orig
tests/unit/modules/test_saltsupport.py.orig
```

On later SLEs, this is not the case because the `patch` command uses the `--no-backup-if-mismatch` option by default.
