### PR TITLE
Make "man" a recommended package instead of required

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -565,7 +565,7 @@ Recommends:     python3-pyinotify
 Requires:       iputils
 Requires:       sudo
 Requires:       file
-Requires:       man
+Recommends:     man
 
 Provides:       bundled(python3-tornado) = 4.5.3
 


### PR DESCRIPTION
This PR makes `man` to be considered as "Recommended" instead of a hard requirement for `python3-salt`, as we know some OSes like SLE Micro, might not really have `man` available.