### PR TITLE
Mark "python3-CherryPy" as recommended package for the Salt testsuite

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -817,7 +817,7 @@ BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools
 
 Requires:       salt = %{version}
-Requires:       python3-CherryPy
+Recommends:     python3-CherryPy
 Requires:       python3-Genshi
 Requires:       python3-Mako
 %if !0%{?suse_version} > 1600 || 0%{?centos}


### PR DESCRIPTION
In some distros, as SL Micro 6, the `python3-CherryPy` package is not available (as salt-api is not shipped in this distro).

The related tests are skipped when `cherrypy` is not available, so we can simply set this package as recommended instead of required.