### PR TITLE
Fix performance of user.list_groups with many remote groups

### DIFF
--- a/salt/add-changlog-entries.patch
+++ b/salt/add-changlog-entries.patch
@@ -1,0 +1,29 @@
+From bdee0b4e5fb1eda397cfd6fb4bae72c5de6ac894 Mon Sep 17 00:00:00 2001
+From: nicholasmhughes <nicholasmhughes@gmail.com>
+Date: Mon, 28 Aug 2023 14:37:30 -0400
+Subject: [PATCH] add changlog entries
+
+---
+ changelog/64953.fixed.md   | 1 +
+ changelog/65029.removed.md | 1 +
+ 2 files changed, 2 insertions(+)
+ create mode 100644 changelog/64953.fixed.md
+ create mode 100644 changelog/65029.removed.md
+
+diff --git a/changelog/64953.fixed.md b/changelog/64953.fixed.md
+new file mode 100644
+index 0000000000..f0b1ed46f1
+--- /dev/null
++++ b/changelog/64953.fixed.md
+@@ -0,0 +1 @@
++Fix user.list_groups omits remote groups via sssd, etc.
+diff --git a/changelog/65029.removed.md b/changelog/65029.removed.md
+new file mode 100644
+index 0000000000..d09f10b4ba
+--- /dev/null
++++ b/changelog/65029.removed.md
+@@ -0,0 +1 @@
++Tech Debt - support for pysss removed due to functionality addition in Python 3.3
+-- 
+2.35.3
+

--- a/salt/add-negative-tests-for-_getgrall.patch
+++ b/salt/add-negative-tests-for-_getgrall.patch
@@ -1,0 +1,53 @@
+From 73658060ab01e70c5cbdfdae4e551239aaf8e6e3 Mon Sep 17 00:00:00 2001
+From: nicholasmhughes <nicholasmhughes@gmail.com>
+Date: Wed, 30 Aug 2023 19:44:50 -0400
+Subject: [PATCH] add negative tests for _getgrall
+
+---
+ changelog/64888.fixed.md                        |  1 +
+ .../functional/utils/user/test__getgrall.py     | 17 ++++++++++++++++-
+ 2 files changed, 17 insertions(+), 1 deletion(-)
+ create mode 100644 changelog/64888.fixed.md
+
+diff --git a/changelog/64888.fixed.md b/changelog/64888.fixed.md
+new file mode 100644
+index 0000000000..08b2efd042
+--- /dev/null
++++ b/changelog/64888.fixed.md
+@@ -0,0 +1 @@
++Fixed grp.getgrall() in utils/user.py causing performance issues
+diff --git a/tests/pytests/functional/utils/user/test__getgrall.py b/tests/pytests/functional/utils/user/test__getgrall.py
+index d13bd2075b..bed8420cd8 100644
+--- a/tests/pytests/functional/utils/user/test__getgrall.py
++++ b/tests/pytests/functional/utils/user/test__getgrall.py
+@@ -9,7 +9,7 @@ import grp
+ import salt.utils.user
+ 
+ 
+-@pytest.fixture()
++@pytest.fixture(scope="function")
+ def etc_group(tmp_path):
+     etcgrp = tmp_path / "etc" / "group"
+     etcgrp.parent.mkdir()
+@@ -34,3 +34,18 @@ def test__getgrall(etc_group):
+     grall = salt.utils.user._getgrall(root=str(etc_group.parent.parent))
+ 
+     assert grall == expected_grall
++
++
++def test__getgrall_permission_denied(etc_group):
++    etc_group.chmod(0o000)
++
++    with pytest.raises(PermissionError):
++        salt.utils.user._getgrall(root=str(etc_group.parent.parent))
++
++
++def test__getgrall_bad_format(etc_group):
++    with etc_group.open("a") as _fp:
++        _fp.write("\n# some comment here\n")
++
++    with pytest.raises(IndexError):
++        salt.utils.user._getgrall(root=str(etc_group.parent.parent))
+-- 
+2.35.3
+

--- a/salt/add-tests-for-_getgrall-and-local-vs-remote-group-ha.patch
+++ b/salt/add-tests-for-_getgrall-and-local-vs-remote-group-ha.patch
@@ -1,0 +1,93 @@
+From a680e596efe178f7931d3841046d7b30aaffe6d4 Mon Sep 17 00:00:00 2001
+From: nicholasmhughes <nicholasmhughes@gmail.com>
+Date: Mon, 28 Aug 2023 20:17:39 -0400
+Subject: [PATCH] add tests for _getgrall and local vs remote group
+ handling
+
+---
+ .../functional/utils/user/test__getgrall.py   | 36 +++++++++++++++++++
+ tests/pytests/unit/utils/test_user.py         | 29 +++++++++++++++
+ 2 files changed, 65 insertions(+)
+ create mode 100644 tests/pytests/functional/utils/user/test__getgrall.py
+ create mode 100644 tests/pytests/unit/utils/test_user.py
+
+diff --git a/tests/pytests/functional/utils/user/test__getgrall.py b/tests/pytests/functional/utils/user/test__getgrall.py
+new file mode 100644
+index 0000000000..d13bd2075b
+--- /dev/null
++++ b/tests/pytests/functional/utils/user/test__getgrall.py
+@@ -0,0 +1,36 @@
++from textwrap import dedent
++
++import pytest
++
++pytest.importorskip("grp")
++
++import grp
++
++import salt.utils.user
++
++
++@pytest.fixture()
++def etc_group(tmp_path):
++    etcgrp = tmp_path / "etc" / "group"
++    etcgrp.parent.mkdir()
++    etcgrp.write_text(
++        dedent(
++            """games:x:50:
++            docker:x:959:debian,salt
++            salt:x:1000:"""
++        )
++    )
++    return etcgrp
++
++
++def test__getgrall(etc_group):
++    group_lines = [
++        ["games", "x", 50, []],
++        ["docker", "x", 959, ["debian", "salt"]],
++        ["salt", "x", 1000, []],
++    ]
++    expected_grall = [grp.struct_group(comps) for comps in group_lines]
++
++    grall = salt.utils.user._getgrall(root=str(etc_group.parent.parent))
++
++    assert grall == expected_grall
+diff --git a/tests/pytests/unit/utils/test_user.py b/tests/pytests/unit/utils/test_user.py
+new file mode 100644
+index 0000000000..17c6b1551f
+--- /dev/null
++++ b/tests/pytests/unit/utils/test_user.py
+@@ -0,0 +1,29 @@
++from types import SimpleNamespace
++
++import pytest
++
++from tests.support.mock import MagicMock, patch
++
++pytest.importorskip("grp")
++
++import grp
++
++import salt.utils.user
++
++
++def test_get_group_list():
++    getpwname = SimpleNamespace(pw_gid=1000)
++    getgrgid = MagicMock(side_effect=[SimpleNamespace(gr_name="remote")])
++    group_lines = [
++        ["games", "x", 50, []],
++        ["salt", "x", 1000, []],
++    ]
++    getgrall = [grp.struct_group(comps) for comps in group_lines]
++    with patch("os.getgrouplist", MagicMock(return_value=[50, 1000, 12000])), patch(
++        "pwd.getpwnam", MagicMock(return_value=getpwname)
++    ), patch("salt.utils.user._getgrall", MagicMock(return_value=getgrall)), patch(
++        "grp.getgrgid", getgrgid
++    ):
++        group_list = salt.utils.user.get_group_list("salt")
++        assert group_list == ["games", "remote", "salt"]
++        getgrgid.assert_called_once()
+-- 
+2.35.3
+

--- a/salt/fixes-saltstack-salt-64953-user.list_groups-omits-re.patch
+++ b/salt/fixes-saltstack-salt-64953-user.list_groups-omits-re.patch
@@ -1,0 +1,76 @@
+From 092f840fc2adb0e13a840bc35bd9b6bc67f89367 Mon Sep 17 00:00:00 2001
+From: nicholasmhughes <nicholasmhughes@gmail.com>
+Date: Mon, 28 Aug 2023 13:53:23 -0400
+Subject: [PATCH] fixes saltstack/salt#64953 user.list_groups omits
+ remote groups
+
+---
+ salt/utils/user.py | 46 ++++++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 42 insertions(+), 4 deletions(-)
+
+diff --git a/salt/utils/user.py b/salt/utils/user.py
+index 2f1ca65cf9..bceb415615 100644
+--- a/salt/utils/user.py
++++ b/salt/utils/user.py
+@@ -293,12 +293,29 @@ def get_group_list(user, include_default=True):
+         # Try os.getgrouplist, available in python >= 3.3
+         log.trace("Trying os.getgrouplist for '%s'", user)
+         try:
+-            user_group_list = os.getgrouplist(user, pwd.getpwnam(user).pw_gid)
+-            group_names = [
++            user_group_list = sorted(os.getgrouplist(user, pwd.getpwnam(user).pw_gid))
++            local_grall = _getgrall()
++            local_gids = sorted(lgrp.gr_gid for lgrp in local_grall)
++            max_idx = -1
++            local_max = local_gids[max_idx]
++            while local_max >= 65000:
++                max_idx -= 1
++                local_max = local_gids[max_idx]
++            user_group_list_local = [
++                lgrp for lgrp in user_group_list if lgrp <= local_max
++            ]
++            user_group_list_remote = [
++                rgrp for rgrp in user_group_list if rgrp > local_max
++            ]
++            local_group_names = [
+                 _group.gr_name
+-                for _group in grp.getgrall()
+-                if _group.gr_gid in user_group_list
++                for _group in local_grall
++                if _group.gr_gid in user_group_list_local
+             ]
++            remote_group_names = [
++                grp.getgrgid(group_id).gr_name for group_id in user_group_list_remote
++            ]
++            group_names = local_group_names + remote_group_names
+         except Exception:  # pylint: disable=broad-except
+             pass
+     elif HAS_PYSSS:
+@@ -389,3 +406,24 @@ def get_gid(group=None):
+             return grp.getgrnam(group).gr_gid
+         except KeyError:
+             return None
++
++
++def _getgrall(root=None):
++    """
++    Alternative implemetantion for getgrall, that uses only /etc/group
++    """
++    ret = []
++    root = "/" if not root else root
++    etc_group = os.path.join(root, "etc/group")
++    with salt.utils.files.fopen(etc_group) as fp_:
++        for line in fp_:
++            line = salt.utils.stringutils.to_unicode(line)
++            comps = line.strip().split(":")
++            # Generate a getgrall compatible output
++            comps[2] = int(comps[2])
++            if comps[3]:
++                comps[3] = [mem.strip() for mem in comps[3].split(",")]
++            else:
++                comps[3] = []
++            ret.append(grp.struct_group(comps))
++    return ret
+-- 
+2.35.3
+

--- a/salt/fixes-saltstack-salt-65029-support-for-pysss-can-be-.patch
+++ b/salt/fixes-saltstack-salt-65029-support-for-pysss-can-be-.patch
@@ -1,0 +1,124 @@
+From 33a9337ca299d8422a370b96d05905653d9a0c07 Mon Sep 17 00:00:00 2001
+From: nicholasmhughes <nicholasmhughes@gmail.com>
+Date: Mon, 28 Aug 2023 14:32:36 -0400
+Subject: [PATCH] fixes saltstack/salt#65029 support for pysss can be
+ removed
+
+---
+ salt/auth/pam.py   |  9 -------
+ salt/utils/user.py | 67 +++++++++++++++++-----------------------------
+ 2 files changed, 24 insertions(+), 52 deletions(-)
+
+diff --git a/salt/auth/pam.py b/salt/auth/pam.py
+index f0397c1062..12af29bbdb 100644
+--- a/salt/auth/pam.py
++++ b/salt/auth/pam.py
+@@ -24,15 +24,6 @@ authenticated against.  This defaults to `login`
+ 
+     The Python interface to PAM does not support authenticating as ``root``.
+ 
+-.. note:: Using PAM groups with SSSD groups on python2.
+-
+-    To use sssd with the PAM eauth module and groups the `pysss` module is
+-    needed.  On RedHat/CentOS this is `python-sss`.
+-
+-    This should not be needed with python >= 3.3, because the `os` modules has the
+-    `getgrouplist` function.
+-
+-
+ .. note:: This module executes itself in a subprocess in order to user the system python
+     and pam libraries. We do this to avoid openssl version conflicts when
+     running under a salt onedir build.
+diff --git a/salt/utils/user.py b/salt/utils/user.py
+index bceb415615..3588b3804a 100644
+--- a/salt/utils/user.py
++++ b/salt/utils/user.py
+@@ -31,13 +31,6 @@ try:
+ except ImportError:
+     HAS_GRP = False
+ 
+-try:
+-    import pysss
+-
+-    HAS_PYSSS = True
+-except ImportError:
+-    HAS_PYSSS = False
+-
+ try:
+     import salt.utils.win_functions
+ 
+@@ -289,47 +282,35 @@ def get_group_list(user, include_default=True):
+         return []
+     group_names = None
+     ugroups = set()
+-    if hasattr(os, "getgrouplist"):
+-        # Try os.getgrouplist, available in python >= 3.3
+-        log.trace("Trying os.getgrouplist for '%s'", user)
+-        try:
+-            user_group_list = sorted(os.getgrouplist(user, pwd.getpwnam(user).pw_gid))
+-            local_grall = _getgrall()
+-            local_gids = sorted(lgrp.gr_gid for lgrp in local_grall)
+-            max_idx = -1
++    # Try os.getgrouplist, available in python >= 3.3
++    log.trace("Trying os.getgrouplist for '%s'", user)
++    try:
++        user_group_list = sorted(os.getgrouplist(user, pwd.getpwnam(user).pw_gid))
++        local_grall = _getgrall()
++        local_gids = sorted(lgrp.gr_gid for lgrp in local_grall)
++        max_idx = -1
++        local_max = local_gids[max_idx]
++        while local_max >= 65000:
++            max_idx -= 1
+             local_max = local_gids[max_idx]
+-            while local_max >= 65000:
+-                max_idx -= 1
+-                local_max = local_gids[max_idx]
+-            user_group_list_local = [
+-                lgrp for lgrp in user_group_list if lgrp <= local_max
+-            ]
+-            user_group_list_remote = [
+-                rgrp for rgrp in user_group_list if rgrp > local_max
+-            ]
+-            local_group_names = [
+-                _group.gr_name
+-                for _group in local_grall
+-                if _group.gr_gid in user_group_list_local
+-            ]
+-            remote_group_names = [
+-                grp.getgrgid(group_id).gr_name for group_id in user_group_list_remote
+-            ]
+-            group_names = local_group_names + remote_group_names
+-        except Exception:  # pylint: disable=broad-except
+-            pass
+-    elif HAS_PYSSS:
+-        # Try pysss.getgrouplist
+-        log.trace("Trying pysss.getgrouplist for '%s'", user)
+-        try:
+-            group_names = list(pysss.getgrouplist(user))
+-        except Exception:  # pylint: disable=broad-except
+-            pass
++        user_group_list_local = [lgrp for lgrp in user_group_list if lgrp <= local_max]
++        user_group_list_remote = [rgrp for rgrp in user_group_list if rgrp > local_max]
++        local_group_names = [
++            _group.gr_name
++            for _group in local_grall
++            if _group.gr_gid in user_group_list_local
++        ]
++        remote_group_names = [
++            grp.getgrgid(group_id).gr_name for group_id in user_group_list_remote
++        ]
++        group_names = local_group_names + remote_group_names
++    except Exception:  # pylint: disable=broad-except
++        pass
+ 
+     if group_names is None:
+         # Fall back to generic code
+         # Include the user's default group to match behavior of
+-        # os.getgrouplist() and pysss.getgrouplist()
++        # os.getgrouplist()
+         log.trace("Trying generic group list for '%s'", user)
+         group_names = [g.gr_name for g in grp.getgrall() if user in g.gr_mem]
+         try:
+-- 
+2.35.3
+

--- a/salt/remove-permission-check-as-its-probably-an-unreachab.patch
+++ b/salt/remove-permission-check-as-its-probably-an-unreachab.patch
@@ -1,0 +1,32 @@
+From 8626074cd2847a29bb52bcb5e7d19b79f6f9f96b Mon Sep 17 00:00:00 2001
+From: nicholasmhughes <nicholasmhughes@gmail.com>
+Date: Fri, 15 Sep 2023 10:32:12 -0400
+Subject: [PATCH] remove permission check as its probably an
+ unreachable edge case
+
+---
+ tests/pytests/functional/utils/user/test__getgrall.py | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/tests/pytests/functional/utils/user/test__getgrall.py b/tests/pytests/functional/utils/user/test__getgrall.py
+index 824cf9b229..db994019e6 100644
+--- a/tests/pytests/functional/utils/user/test__getgrall.py
++++ b/tests/pytests/functional/utils/user/test__getgrall.py
+@@ -36,14 +36,6 @@ def test__getgrall(etc_group):
+     assert grall == expected_grall
+ 
+ 
+-@pytest.mark.skip_if_root()
+-def test__getgrall_permission_denied(etc_group):
+-    etc_group.chmod(0o000)
+-
+-    with pytest.raises(PermissionError):
+-        salt.utils.user._getgrall(root=str(etc_group.parent.parent))
+-
+-
+ def test__getgrall_bad_format(etc_group):
+     with etc_group.open("a") as _fp:
+         _fp.write("\n# some comment here\n")
+-- 
+2.35.3
+

--- a/salt/root-can-still-read-the-file-and-tests-run-as-root.patch
+++ b/salt/root-can-still-read-the-file-and-tests-run-as-root.patch
@@ -1,0 +1,24 @@
+From 8c1767f781df5169bfeef3317baa135b938379bd Mon Sep 17 00:00:00 2001
+From: nicholasmhughes <nicholasmhughes@gmail.com>
+Date: Fri, 1 Sep 2023 17:13:03 -0400
+Subject: [PATCH] root can still read the file and tests run as root
+
+---
+ tests/pytests/functional/utils/user/test__getgrall.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/tests/pytests/functional/utils/user/test__getgrall.py b/tests/pytests/functional/utils/user/test__getgrall.py
+index bed8420cd8..824cf9b229 100644
+--- a/tests/pytests/functional/utils/user/test__getgrall.py
++++ b/tests/pytests/functional/utils/user/test__getgrall.py
+@@ -36,6 +36,7 @@ def test__getgrall(etc_group):
+     assert grall == expected_grall
+ 
+ 
++@pytest.mark.skip_if_root()
+ def test__getgrall_permission_denied(etc_group):
+     etc_group.chmod(0o000)
+ 
+-- 
+2.35.3
+

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -402,6 +402,14 @@ Patch120:       provide-systemd-timer-unit.patch
 Patch121:       skip-certain-tests-if-necessary-and-mark-some-flaky-.patch
 # PATCH-FIX_UPSTREAM https://github.com/saltstack/salt/pull/66647
 Patch122:       fix-status.diskusage-and-exclude-some-tests-to-run-w.patch
+# PATCH-FIX_UPSTREAM https://github.com/saltstack/salt/pull/65077
+Patch123:       fixes-saltstack-salt-64953-user.list_groups-omits-re.patch
+Patch124:       fixes-saltstack-salt-65029-support-for-pysss-can-be-.patch
+Patch125:       add-changlog-entries.patch
+Patch126:       add-tests-for-_getgrall-and-local-vs-remote-group-ha.patch
+Patch127:       add-negative-tests-for-_getgrall.patch
+Patch128:       root-can-still-read-the-file-and-tests-run-as-root.patch
+Patch129:       remove-permission-check-as-its-probably-an-unreachab.patch
 
 ### IMPORTANT: The line below is used as a snippet marker. Do not touch it.
 ### SALT PATCHES LIST END


### PR DESCRIPTION
Fix performance of user.list_groups with many remote groups

 *Add fixes-saltstack-salt-64953-user.list_groups-omits-re.patch
 *Add fixes-saltstack-salt-65029-support-for-pysss-can-be-.patch
 *Add add-changlog-entries.patch
 *Add add-negative-tests-for-_getgrall.patch
 *Add add-tests-for-_getgrall-and-local-vs-remote-group-ha.patch
 *Add remove-permission-check-as-its-probably-an-unreachab.patch
 *Add root-can-still-read-the-file-and-tests-run-as-root.patch