### PR TITLE
Set "contextvars" as a build requirement for package

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -528,6 +528,7 @@ BuildRequires:  python3-requests >= 1.0.0
 BuildRequires:  python3-distro
 BuildRequires:  python3-looseversion
 BuildRequires:  python3-packaging
+BuildRequires:  python3-contextvars
 
 # requirements/zeromq.txt
 %if %{with test}


### PR DESCRIPTION
After the recent refactor done on `salt/utils/ctx.py` via https://build.opensuse.org/request/show/1197884, now `contextvars` is required at package building time to avoid getting this error:
```
[   28s] Traceback (most recent call last):
[   28s]   File "/home/abuild/rpmbuild/BUILD/salt-3006.0-suse/salt/utils/ctx.py", line 5, in <module>
[   28s]     import _contextvars as contextvars
[   28s] ModuleNotFoundError: No module named '_contextvars'
[   28s] 
[   28s] During handling of the above exception, another exception occurred:
[   28s] 
[   28s] Traceback (most recent call last):
[   28s]   File "setup.py", line 1266, in <module>
[   28s]     setup(distclass=SaltDistribution)
[   28s]   File "/usr/lib/python3.6/site-packages/setuptools/__init__.py", line 162, in setup
[   28s]     return distutils.core.setup(**attrs)
[   28s]   File "/usr/lib64/python3.6/distutils/core.py", line 148, in setup
[   28s]     dist.run_commands()
[   28s]   File "/usr/lib64/python3.6/distutils/dist.py", line 955, in run_commands
[   28s]     self.run_command(cmd)
[   28s]   File "/usr/lib64/python3.6/distutils/dist.py", line 974, in run_command
[   28s]     cmd_obj.run()
[   28s]   File "setup.py", line 596, in run
[   28s]     self.run_command("write_salt_version")
[   28s]   File "/usr/lib64/python3.6/distutils/cmd.py", line 313, in run_command
[   28s]     self.distribution.run_command(command)
[   28s]   File "/usr/lib64/python3.6/distutils/dist.py", line 974, in run_command
[   28s]     cmd_obj.run()
[   28s]   File "setup.py", line 228, in run
[   28s]     from salt.version import SaltStackVersion
[   28s]   File "/home/abuild/rpmbuild/BUILD/salt-3006.0-suse/salt/__init__.py", line 175, in <module>
[   28s]     import salt._logging  # isort:skip
[   28s]   File "/home/abuild/rpmbuild/BUILD/salt-3006.0-suse/salt/_logging/__init__.py", line 12, in <module>
[   28s]     from salt._logging.impl import (
[   28s]   File "/home/abuild/rpmbuild/BUILD/salt-3006.0-suse/salt/_logging/impl.py", line 29, in <module>
[   28s]     import salt.utils.ctx
[   28s]   File "/home/abuild/rpmbuild/BUILD/salt-3006.0-suse/salt/utils/ctx.py", line 8, in <module>
[   28s]     import contextvars
[   28s] ModuleNotFoundError: No module named 'contextvars'
[   28s] error: Bad exit status from /var/tmp/rpm-tmp.sBXedy (%build)
```