### PR TITLE
Add missing requires python3-cryptography for x509

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -624,6 +624,7 @@ Requires:       python3-distro
 Requires:       python3-looseversion
 Requires:       python3-packaging
 Requires:       python3-contextvars
+Requires:       python3-cryptography
 %if 0%{?suse_version}
 # required for zypper.py
 Requires:       python3-rpm


### PR DESCRIPTION
See https://progress.opensuse.org/issues/167830

```
[DEBUG   ] Failed to import utils x509:
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/salt/loader/lazy.py", line 772, in _load_module
    mod = self.run(spec.loader.load_module)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/loader/lazy.py", line 1234, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/loader/lazy.py", line 1249, in _run_as
    ret = _func_or_method(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap_external>", line 605, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 1120, in load_module
  File "<frozen importlib._bootstrap_external>", line 945, in load_module
  File "<frozen importlib._bootstrap>", line 290, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 721, in _load
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/usr/lib/python3.11/site-packages/salt/utils/x509.py", line 11, in <module>
    import cryptography
ModuleNotFoundError: No module named 'cryptography'
```