### PR TITLE
Include passlib as a dependency

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -649,6 +649,7 @@ Requires:       iputils
 Requires:       sudo
 Requires:       file
 Recommends:     man
+Recommends:     python3-passlib
 
 Provides:       bundled(python3-tornado) = 4.5.3
 


### PR DESCRIPTION
We added passlib to Salt bundle, but not here; WDYT?