### PR TITLE
Use update-alternatives for all salt scripts

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -34,7 +34,7 @@
 %define psuffix %{nil}
 %endif
 
-%if 0%{?suse_version} > 1210 || 0%{?rhel} >= 7 || 0%{?fedora} >=28
+%if 0%{?suse_version} > 1210 || 0%{?rhel} >= 7 || 0%{?fedora} >= 28
 %bcond_without systemd
 %else
 %bcond_with    systemd
@@ -574,10 +574,6 @@ BuildRequires:  bash
 BuildRequires:  zsh
 %endif
 
-%if 0%{?rhel} || 0%{?fedora}
-BuildRequires:  yum
-%endif
-
 %define python_subpackage_only 1
 %python_subpackages
 
@@ -672,13 +668,10 @@ Requires:       python3-m2crypto
 Requires:       python3-markupsafe
 Requires:       python3-msgpack > 0.3
 Requires:       python3-zmq >= 2.2.0
-Requires:       yum
 
-%if 0%{?rhel} == 8 || 0%{?fedora} >= 30
+%if 0%{?rhel} >= 8 || 0%{?fedora} >= 30
 Requires:       dnf
-%endif
-%if 0%{?rhel} == 6
-Requires:       yum-plugin-security
+Requires:       python3-dnf-plugins-core
 %endif
 %else # SUSE
 %if 0%{?singlespec_compat}
@@ -744,15 +737,18 @@ Suggests:       python-gnupg
 # python-xml is part of python-base in all rhel versions
 %if 0%{?singlespec_compat}
 Requires:       %{python_module xml}
+Requires:       %{python_module zypp-plugin}
 Suggests:       %{python_module Mako}
 Recommends:     %{python_module netaddr}
 Recommends:     %{python_module pyinotify}
 %else
 Requires:       python-xml
+Requires:       python-zypp-plugin
 Suggests:       python-Mako
 Recommends:     python-netaddr
 Recommends:     python-pyinotify
 %endif
+Requires(pre):  libzypp(plugin:system) >= 0
 %endif
 
 # Required by Salt modules
@@ -865,10 +861,6 @@ Group:          System/Management
 Requires:       %{name} = %{version}-%{release}
 %if 0%{?suse_version} > 1500 || 0%{?sle_version} > 150000
 Requires:       (%{name}-transactional-update = %{version}-%{release} if read-only-root-fs)
-%endif
-%if 0%{?suse_version}
-Requires:       python3-zypp-plugin
-Requires(pre):  libzypp(plugin:system) >= 0
 %endif
 
 %if %{with systemd}
@@ -1175,11 +1167,9 @@ cp -a conf %{buildroot}%{$python_sitelib}/salt-testsuite/
 %if 0%{?suse_version}
 install -Dd -m 0750 %{buildroot}%{_prefix}/lib/zypp/plugins/commit
 %{__install} scripts/suse/zypper/plugins/commit/zyppnotify %{buildroot}%{_prefix}/lib/zypp/plugins/commit/zyppnotify
-sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' %{buildroot}%{_prefix}/lib/zypp/plugins/commit/zyppnotify
 %endif
 
-# Install Yum plugins only on RH machines
-%if 0%{?fedora} || 0%{?rhel}
+# Install DNF plugin only on RH machines
 %if 0%{?fedora} >= 22 || 0%{?rhel} >= 8
 install -Dd %{buildroot}%{python3_sitelib}/dnf-plugins
 install -Dd %{buildroot}%{python3_sitelib}/dnf-plugins/__pycache__
@@ -1188,14 +1178,6 @@ install -Dd %{buildroot}%{_sysconfdir}/dnf/plugins
 %{__install} scripts/suse/dnf/plugins/dnfnotify.conf %{buildroot}%{_sysconfdir}/dnf/plugins
 %{__python3} -m compileall -d %{python3_sitelib}/dnf-plugins %{buildroot}%{python3_sitelib}/dnf-plugins/dnfnotify.py
 %{__python3} -O -m compileall -d %{python3_sitelib}/dnf-plugins %{buildroot}%{python3_sitelib}/dnf-plugins/dnfnotify.py
-%else
-install -Dd %{buildroot}%{_prefix}/share/yum-plugins
-install -Dd %{buildroot}%{_sysconfdir}/yum/pluginconf.d
-%{__install} scripts/suse/yum/plugins/yumnotify.py %{buildroot}%{_prefix}/share/yum-plugins
-%{__install} scripts/suse/yum/plugins/yumnotify.conf %{buildroot}%{_sysconfdir}/yum/pluginconf.d
-%{__python} -m compileall -d %{_prefix}/share/yum-plugins %{buildroot}%{_prefix}/share/yum-plugins/yumnotify.py
-%{__python} -O -m compileall -d %{_prefix}/share/yum-plugins %{buildroot}%{_prefix}/share/yum-plugins/yumnotify.py
-%endif
 %endif
 
 ## install init and systemd scripts
@@ -1274,6 +1256,9 @@ for SALT_SCRIPT in salt salt-api salt-cloud salt-cp salt-key salt-master salt-mi
 %python_clone -a %{buildroot}%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}
     ln -s "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}" "%{buildroot}%{_bindir}/${SALT_SCRIPT}"
 done
+mv "%{buildroot}%{_prefix}/lib/zypp/plugins/commit/zyppnotify" "%{buildroot}%{_exec_prefix}/libexec/salt/"
+%python_clone -a %{buildroot}%{_exec_prefix}/libexec/salt/zyppnotify
+ln -s "%{_exec_prefix}/libexec/salt/zyppnotify" "%{buildroot}%{_prefix}/lib/zypp/plugins/commit/zyppnotify"
 %endif
 
 %endif
@@ -1510,7 +1495,7 @@ for SALT_SCRIPT in salt-call salt-support spm; do
         update-alternatives --quiet --remove "${SALT_SCRIPT}" "%{_bindir}/${SALT_SCRIPT}-%{python_bin_suffix}"
     fi
 done
-for SALT_SCRIPT in salt salt-api salt-cloud salt-cp salt-key salt-master salt-minion salt-proxy salt-run salt-ssh salt-syndic; do
+for SALT_SCRIPT in salt salt-api salt-cloud salt-cp salt-key salt-master salt-minion salt-proxy salt-run salt-ssh salt-syndic zyppnotify; do
     [ -h "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}" ] || rm -f "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}"
     if [ "$1" -gt 0 ] && [ -f /usr/sbin/update-alternatives ]; then
         update-alternatives --quiet --remove "${SALT_SCRIPT}" "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}-%{python_bin_suffix}"
@@ -1522,7 +1507,7 @@ for SALT_SCRIPT in salt-call salt-support spm; do
     update-alternatives --quiet --install "%{_bindir}/${SALT_SCRIPT}" "${SALT_SCRIPT}" \
         "%{_bindir}/${SALT_SCRIPT}-%{python_bin_suffix}" %{python_version_nodots}
 done
-for SALT_SCRIPT in salt salt-api salt-cloud salt-cp salt-key salt-master salt-minion salt-proxy salt-run salt-ssh salt-syndic; do
+for SALT_SCRIPT in salt salt-api salt-cloud salt-cp salt-key salt-master salt-minion salt-proxy salt-run salt-ssh salt-syndic zyppnotify; do
     update-alternatives --quiet --install "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}" "${SALT_SCRIPT}" \
         "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}-%{python_bin_suffix}" %{python_version_nodots}
 done
@@ -1533,7 +1518,7 @@ for SALT_SCRIPT in salt-call salt-support spm; do
         update-alternatives --quiet --remove "${SALT_SCRIPT}" "%{_bindir}/${SALT_SCRIPT}-%{python_bin_suffix}"
     fi
 done
-for SALT_SCRIPT in salt salt-api salt-cloud salt-cp salt-key salt-master salt-minion salt-proxy salt-run salt-ssh salt-syndic; do
+for SALT_SCRIPT in salt salt-api salt-cloud salt-cp salt-key salt-master salt-minion salt-proxy salt-run salt-ssh salt-syndic zyppnotify; do
     if [ ! -e "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}-%{python_bin_suffix}" ]; then
         update-alternatives --quiet --remove "${SALT_SCRIPT}" "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}-%{python_bin_suffix}"
     fi
@@ -1603,16 +1588,11 @@ rm -f %{_localstatedir}/cache/salt/minion/thin/version
 %{_prefix}/lib/zypp/plugins/commit/zyppnotify
 %endif
 
-# Install Yum plugins only on RH machines
-%if 0%{?fedora} || 0%{?rhel}
+# Install DNF plugin only on RH machines
 %if 0%{?fedora} >= 22 || 0%{?rhel} >= 8
 %{python3_sitelib}/dnf-plugins/dnfnotify.py
 %{python3_sitelib}/dnf-plugins/__pycache__/dnfnotify.*
 %{_sysconfdir}/dnf/plugins/dnfnotify.conf
-%else
-%{_prefix}/share/yum-plugins/yumnotify.*
-%{_sysconfdir}/yum/pluginconf.d/yumnotify.conf
-%endif
 %endif
 
 %if %{with systemd}
@@ -1710,7 +1690,9 @@ rm -f %{_localstatedir}/cache/salt/minion/thin/version
 %python_alternative %{_exec_prefix}/libexec/salt/salt-run
 %python_alternative %{_exec_prefix}/libexec/salt/salt-ssh
 %python_alternative %{_exec_prefix}/libexec/salt/salt-syndic
+%python_alternative %{_exec_prefix}/libexec/salt/zyppnotify
 %endif
+
 %dir %{python_sitelib}/salt
 %dir %{python_sitelib}/salt-*.egg-info
 %{python_sitelib}/salt/*

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -783,7 +783,11 @@ Group:          System/Management
 Requires:       %{name} = %{version}-%{release}
 Requires:       %{name}-master = %{version}-%{release}
 %if 0%{?suse_version}
+%if 0%{?sle_version} >= 150400
+Requires:       %{python_module CherryPy >= 3.2.2 if %python-salt}
+%else
 Requires:       python3-CherryPy >= 3.2.2
+%endif
 %else
 Requires:       python3-cherrypy >= 3.2.2
 %endif
@@ -796,10 +800,18 @@ Summary:        Generic cloud provisioning tool for Saltstack
 Group:          System/Management
 Requires:       %{name} = %{version}-%{release}
 Requires:       %{name}-master = %{version}-%{release}
-Requires:       python3-apache-libcloud
 %if 0%{?suse_version}
+%if 0%{?sle_version} >= 150400
+Requires:       %{python_module apache-libcloud if %python-salt}
+Recommends:     %{python_module botocore if %python-salt}
+Recommends:     %{python_module netaddr if %python-salt}
+%else
+Requires:       python3-apache-libcloud
 Recommends:     python3-botocore
 Recommends:     python3-netaddr
+%endif
+%else
+Requires:       python3-apache-libcloud
 %endif
 
 %description cloud
@@ -822,7 +834,11 @@ Summary:        The management component of Saltstack with zmq protocol supporte
 Group:          System/Management
 Requires:       %{name} = %{version}-%{release}
 %if 0%{?suse_version}
+%if 0%{?sle_version} >= 150400
+Recommends:     %{python_module pygit2 >= 0.20.3 if %python-salt}
+%else
 Recommends:     python3-pygit2 >= 0.20.3
+%endif
 %endif
 %ifarch %{ix86} x86_64
 %if 0%{?suse_version}

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -58,6 +58,7 @@
 %{?sle15allpythons}
 %define skip_python2 1
 %if 0%{?rhel} == 8 || (0%{?suse_version} == 1500 && 0%{?sle_version} < 150400)
+%define singlespec_compat 1
 %define __python3_bin_suffix 3.6
 %if 0%{?rhel} == 8
 %define __python3 /usr/libexec/platform-python
@@ -77,7 +78,6 @@ args = args:gsub("$python_sitelib", "python3_sitelib")\
 args = args:gsub("$python", python_bin)\
 print(rpm.expand(args .. "\\n"))\
 }
-%define _nosinglespec 1
 %endif
 Name:           salt%{psuffix}
 Version:        3006.0
@@ -591,7 +591,7 @@ servers, handle them quickly and through a simple and manageable interface.
 
 %if "%{flavor}" != "testsuite"
 
-%if 0%{?_nosinglespec}
+%if 0%{?singlespec_compat}
 %package -n python3-salt
 %else
 %package -n python-salt
@@ -648,7 +648,7 @@ BuildRequires:  %{python_module sphinx}
 %if 0%{?rhel} == 8
 Requires:       platform-python
 %else
-%if 0%{?_nosinglespec}
+%if 0%{?singlespec_compat}
 Requires:       %{python_module base}
 %else
 Requires:       python-base
@@ -681,7 +681,7 @@ Requires:       dnf
 Requires:       yum-plugin-security
 %endif
 %else # SUSE
-%if 0%{?_nosinglespec}
+%if 0%{?singlespec_compat}
 Requires:       %{python_module Jinja2}
 Requires:       %{python_module MarkupSafe}
 Requires:       %{python_module msgpack-python > 0.3}
@@ -703,7 +703,7 @@ Requires:       python-pycrypto >= 2.6.1
 Requires:       python-pyzmq >= 2.2.0
 %endif
 %endif # end of RHEL / SUSE specific section
-%if 0%{?_nosinglespec}
+%if 0%{?singlespec_compat}
 Recommends:     %{python_module jmespath}
 Requires:       %{python_module PyYAML}
 Requires:       %{python_module psutil}
@@ -742,7 +742,7 @@ Suggests:       python-gnupg
 #
 %if 0%{?suse_version}
 # python-xml is part of python-base in all rhel versions
-%if 0%{?_nosinglespec}
+%if 0%{?singlespec_compat}
 Requires:       %{python_module xml}
 Suggests:       %{python_module Mako}
 Recommends:     %{python_module netaddr}
@@ -762,7 +762,7 @@ Requires:       file
 Recommends:     man
 Recommends:     python3-passlib
 
-%if 0%{?_nosinglespec}
+%if 0%{?singlespec_compat}
 Provides:       bundled(%{python_module tornado}) = 4.5.3
 %else
 Provides:       bundled(python-tornado) = 4.5.3
@@ -770,7 +770,7 @@ Provides:       bundled(python-tornado) = 4.5.3
 
 Provides:       %{name}-call = %{version}-%{release}
 
-%if 0%{?_nosinglespec}
+%if 0%{?singlespec_compat}
 %description -n python3-salt
 %else
 %description -n python-salt
@@ -978,8 +978,8 @@ list of active executors.  This package add the configuration file.
 
 %if "%{flavor}" == "testsuite"
 
-%if 0%{?_nosinglespec}
-%package -n %{python_module salt-testsuite}
+%if 0%{?singlespec_compat}
+%package -n python3-salt-testsuite
 %else
 %package -n python-salt-testsuite
 %endif
@@ -993,7 +993,7 @@ BuildRequires:  %{python_module base}
 BuildRequires:  %{python_module setuptools}
 
 Requires:       salt = %{version}
-%if 0%{?_nosinglespec}
+%if 0%{?singlespec_compat}
 Recommends:     %{python_module CherryPy}
 Requires:       %{python_module Genshi}
 Requires:       %{python_module Mako}
@@ -1040,7 +1040,7 @@ Requires:       git
 
 Obsoletes:      %{name}-tests
 
-%if 0%{?_nosinglespec}
+%if 0%{?singlespec_compat}
 %description -n python3-salt-testsuite
 %else
 %description -n python-salt-testsuite
@@ -1250,6 +1250,14 @@ install -Dpm 0640 conf/suse/standalone-formulas-configuration.conf %{buildroot}%
 
 %if 0%{?_alternatives}
 %python_clone -a %{buildroot}%{_bindir}/salt-call
+%python_clone -a %{buildroot}%{_bindir}/salt-support
+%python_clone -a %{buildroot}%{_bindir}/spm
+install -Dd -m 0750 %{buildroot}%{_exec_prefix}/libexec/salt
+for SALT_SCRIPT in salt salt-api salt-cloud salt-cp salt-key salt-master salt-minion salt-proxy salt-run salt-ssh salt-syndic; do
+    mv "%{buildroot}%{_bindir}/${SALT_SCRIPT}" "%{buildroot}%{_exec_prefix}/libexec/salt/"
+%python_clone -a %{buildroot}%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}
+    ln -s "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}" "%{buildroot}%{_bindir}/${SALT_SCRIPT}"
+done
 %endif
 
 %endif
@@ -1272,10 +1280,6 @@ getent passwd salt >/dev/null || %{_sbindir}/useradd -r -g salt -d $S_HOME -s /b
 if [[ -d "$S_PHOME/.ssh" ]]; then
     mv $S_PHOME/.ssh $S_HOME
 fi
-%if 0%{?_alternatives}
-[ -h %{_bindir}/salt-call ] || rm -f %{_bindir}/salt-call
-%python_libalternatives_reset_alternative salt-call
-%endif
 
 %post
 %if %{with systemd}
@@ -1484,17 +1488,43 @@ fi
 
 %if 0%{?_alternatives}
 %pre -n python-salt
-[ -h %{_bindir}/salt-call ] || rm -f %{_bindir}/salt-call
-%python_libalternatives_reset_alternative salt-call
+for SALT_SCRIPT in salt-call salt-support spm; do
+    [ -h "%{_bindir}/${SALT_SCRIPT}" ] || rm -f "%{_bindir}/${SALT_SCRIPT}"
+    if [ "$1" -gt 0 ] && [ -f /usr/sbin/update-alternatives ]; then
+        update-alternatives --quiet --remove "${SALT_SCRIPT}" "%{_bindir}/${SALT_SCRIPT}-%{python_bin_suffix}"
+    fi
+done
+for SALT_SCRIPT in salt salt-api salt-cloud salt-cp salt-key salt-master salt-minion salt-proxy salt-run salt-ssh salt-syndic; do
+    [ -h "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}" ] || rm -f "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}"
+    if [ "$1" -gt 0 ] && [ -f /usr/sbin/update-alternatives ]; then
+        update-alternatives --quiet --remove "${SALT_SCRIPT}" "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}-%{python_bin_suffix}"
+    fi
+done
 
 %post -n python-salt
-%python_install_alternative salt-call
+for SALT_SCRIPT in salt-call salt-support spm; do
+    update-alternatives --quiet --install "%{_bindir}/${SALT_SCRIPT}" "${SALT_SCRIPT}" \
+        "%{_bindir}/${SALT_SCRIPT}-%{python_bin_suffix}" %{python_version_nodots}
+done
+for SALT_SCRIPT in salt salt-api salt-cloud salt-cp salt-key salt-master salt-minion salt-proxy salt-run salt-ssh salt-syndic; do
+    update-alternatives --quiet --install "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}" "${SALT_SCRIPT}" \
+        "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}-%{python_bin_suffix}" %{python_version_nodots}
+done
 
 %postun -n python-salt
-%python_uninstall_alternative salt-call
+for SALT_SCRIPT in salt-call salt-support spm; do
+    if [ ! -e "%{_bindir}/${SALT_SCRIPT}-%{python_bin_suffix}" ]; then
+        update-alternatives --quiet --remove "${SALT_SCRIPT}" "%{_bindir}/${SALT_SCRIPT}-%{python_bin_suffix}"
+    fi
+done
+for SALT_SCRIPT in salt salt-api salt-cloud salt-cp salt-key salt-master salt-minion salt-proxy salt-run salt-ssh salt-syndic; do
+    if [ ! -e "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}-%{python_bin_suffix}" ]; then
+        update-alternatives --quiet --remove "${SALT_SCRIPT}" "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}-%{python_bin_suffix}"
+    fi
+done
 %endif
 
-%if 0%{?_nosinglespec}
+%if 0%{?singlespec_compat}
 %posttrans -n %{python_module salt}
 %else
 %posttrans -n python-salt
@@ -1649,6 +1679,21 @@ rm -f %{_localstatedir}/cache/salt/minion/thin/version
 %defattr(-,root,root,-)
 %if 0%{?_alternatives}
 %python_alternative %{_bindir}/salt-call
+%python_alternative %{_bindir}/salt-support
+%python_alternative %{_bindir}/spm
+%dir %{_exec_prefix}/libexec
+%dir %attr(0755, root, root) %{_exec_prefix}/libexec/salt
+%python_alternative %{_exec_prefix}/libexec/salt/salt
+%python_alternative %{_exec_prefix}/libexec/salt/salt-api
+%python_alternative %{_exec_prefix}/libexec/salt/salt-cloud
+%python_alternative %{_exec_prefix}/libexec/salt/salt-cp
+%python_alternative %{_exec_prefix}/libexec/salt/salt-key
+%python_alternative %{_exec_prefix}/libexec/salt/salt-master
+%python_alternative %{_exec_prefix}/libexec/salt/salt-minion
+%python_alternative %{_exec_prefix}/libexec/salt/salt-proxy
+%python_alternative %{_exec_prefix}/libexec/salt/salt-run
+%python_alternative %{_exec_prefix}/libexec/salt/salt-ssh
+%python_alternative %{_exec_prefix}/libexec/salt/salt-syndic
 %endif
 %dir %{python_sitelib}/salt
 %dir %{python_sitelib}/salt-*.egg-info


### PR DESCRIPTION
Alternative to https://github.com/openSUSE/salt-packaging/pull/103
This change is introducing usage `update-alternatives` for all the `salt` scripts shipped with the separate binary subpackages.

This change is intended to avoid increasing the number of binary packages produced by `salt` source package, while providing the possibility to use `salt` module with different python versions.

Before:
`salt-master`, `salt-minion`, `salt-api` etc. were shipped as a plain python scripts with the binary packages named accordingly and there was no any option to switch the script to use another python version even if `salt` python module was shipped for `3.11` the scripts were attached to the default platform python (`3.6`).

After:
Python version specific scripts like `salt-master-3.6`, `salt-minion-3.6`, `salt-api-3.6`, `salt-master-3.11`, `salt-minion-3.11`, `salt-api-3.11` etc. are stored in `/usr/libexec/salt/` and linked to `salt-master`, `salt-minion`, `salt-api` etc. in the same directory with `update-alternatives`.
While `salt-master`, `salt-minion`, `salt-api` etc. in `/usr/bin/` are the symbolic links to `/usr/libexec/salt/salt-...` delivered with the packages named the same way as before.

#### Additional fixes included in this PR:
- Make Salt Minion to require flavored python "zypp-plugin"
- Use alternatives with "zyppnotify" plugin
- Drop "yumnotify" plugin from spec file
- Add explict dependency to "python3-dnf-plugins-core" for RHEL based
- Remove unnecessary code to fix shebang on zyppnotify

NOTE: OBS packages building at: https://build.opensuse.org/package/show/home:PSuarezHernandez:branches:systemsmanagement:saltstack:products:testing/salt