### PR TITLE
Suggests %{primary_python}-%{name}

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -550,6 +550,7 @@ BuildRequires:  fdupes
 
 %if 0%{?_alternatives}
 Requires:       %{name}-call = %{version}-%{release}
+Suggests:       %{primary_python}-%{name}
 %else
 Requires:       python3-%{name} = %{version}-%{release}
 %endif


### PR DESCRIPTION
While requiring %{name}-call gives a working installation, we want to have
a little bit more control over what python version to be used when nothing
has been specified.

Help libzypp to pick the preferred version of the python-package. This
used to be 'fine', as long as python311 was the default.

Unless zypp gets some hints (in form of the hereby added Suggests) it will
pick any of the available providers, pseudo-randomly (alphabetically the
first choice, which happens to favor python311-salt over python313-salt).
