### PR TITLE
Do not build "python3-salt" anymore for SLE15SP7+

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -685,6 +685,12 @@ Requires:       python-base
 %endif
 %endif
 
+# In case of SLE15SP7+ no more python3-salt anymore
+%if 0%{?suse_version} == 1500 && 0%{?sle_version} >= 150700
+Obsoletes:      python3-salt < %{version}-%{release}
+Provides:       python3-salt = %{version}-%{release}
+%endif
+
 %if 0%{?_alternatives}
 %if %{with libalternatives}
 Requires:       alts

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -54,8 +54,11 @@
 %if %{without systemd}
 %define service_del_preun echo %{*}
 %endif
-
+%if 0%{?suse_version} == 1500 && 0%{?sle_version} >= 150700
+%{?sle15_python_module_pythons}
+%else
 %{?sle15allpythons}
+%endif
 %define skip_python2 1
 %if 0%{?rhel} == 8 || (0%{?suse_version} == 1500 && 0%{?sle_version} < 150400)
 %define singlespec_compat 1

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -558,6 +558,11 @@ Requires:       python3-%{name} = %{version}-%{release}
 %endif
 Obsoletes:      python2-%{name}
 
+# The "salt" package obsoletes "python3-salt" in SLE15SP7+
+%if 0%{?sle_version} >= 150700
+Obsoletes:      python3-%{name}
+%endif
+
 Requires(pre):  %{_sbindir}/groupadd
 Requires(pre):  %{_sbindir}/useradd
 Provides:       user(salt)
@@ -683,12 +688,6 @@ Requires:       %{python_module base}
 %else
 Requires:       python-base
 %endif
-%endif
-
-# In case of SLE15SP7+ no more python3-salt anymore
-%if 0%{?sle_version} >= 150700
-Obsoletes:      python3-salt < %{version}-%{release}
-Provides:       python3-salt = %{version}-%{release}
 %endif
 
 %if 0%{?_alternatives}

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -54,7 +54,7 @@
 %if %{without systemd}
 %define service_del_preun echo %{*}
 %endif
-%if 0%{?suse_version} == 1500 && 0%{?sle_version} >= 150700
+%if 0%{?sle_version} >= 150700
 %{?sle15_python_module_pythons}
 %else
 %{?sle15allpythons}
@@ -686,7 +686,7 @@ Requires:       python-base
 %endif
 
 # In case of SLE15SP7+ no more python3-salt anymore
-%if 0%{?suse_version} == 1500 && 0%{?sle_version} >= 150700
+%if 0%{?sle_version} >= 150700
 Obsoletes:      python3-salt < %{version}-%{release}
 Provides:       python3-salt = %{version}-%{release}
 %endif


### PR DESCRIPTION
As we are dropping Python 3.6 support for Salt on SLE15SP7, this PR just prevent the "python3-salt" package to be built.

This would also hopefully helps preventing the issues on SP7 staging projects, where the existance of "python3-salt" package, together with "salt" seems to mess the module population.

Staging:Y: https://build.suse.de/project/show/SUSE:SLE-15-SP7:GA:Staging:Y