### PR TITLE
Set "python-CherryPy" as required for "python-salt-testsuite"

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -1072,7 +1072,7 @@ BuildRequires:  %{python_module setuptools}
 
 Requires:       salt = %{version}
 %if 0%{?singlespec_compat}
-Recommends:     %{python_module CherryPy}
+Requires:       %{python_module CherryPy}
 Requires:       %{python_module Genshi}
 Requires:       %{python_module Mako}
 %if !0%{?suse_version} > 1600 || 0%{?centos}
@@ -1092,7 +1092,7 @@ Requires:       %{python_module testinfra}
 Requires:       %{python_module yamllint}
 Requires:       %{python_module pip}
 %else
-Recommends:     python-CherryPy
+Requires:       python-CherryPy
 Requires:       python-Genshi
 Requires:       python-Mako
 %if !0%{?suse_version} > 1600 || 0%{?centos}


### PR DESCRIPTION
The `python-CherryPy` package was defined as "Recommended" for `python-salt-testsuite` package.

This is actually wrong as currently tests require `python-CherryPy` to run, otherwise errors are raised when executing the tests:

```
[2025-09-10T10:51:48.397Z] Traceback (most recent call last):
[2025-09-10T10:51:48.397Z] File "/usr/lib64/python3.11/importlib/__init__.py", line 126, in import_module
[2025-09-10T10:51:48.397Z] return _bootstrap._gcd_import(name[level:], package, level)
[2025-09-10T10:51:48.397Z] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[2025-09-10T10:51:48.397Z] File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
[2025-09-10T10:51:48.397Z] File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
[2025-09-10T10:51:48.397Z] File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
[2025-09-10T10:51:48.397Z] File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
[2025-09-10T10:51:48.397Z] File "/usr/lib/python3.11/site-packages/_pytest/assertion/rewrite.py", line 171, in exec_module
[2025-09-10T10:51:48.397Z] exec(co, module.__dict__)
[2025-09-10T10:51:48.397Z] File "/usr/lib/python3.6/site-packages/salt-testsuite/tests/pytests/integration/netapi/rest_cherrypy/conftest.py", line 4, in <module>
[2025-09-10T10:51:48.397Z] import salt.netapi.rest_cherrypy.app
[2025-09-10T10:51:48.397Z] File "/usr/lib/python3.11/site-packages/salt/netapi/rest_cherrypy/app.py", line 599, in <module>
[2025-09-10T10:51:48.397Z] import cherrypy  # pylint: disable=import-error,3rd-party-module-not-gated
[2025-09-10T10:51:48.397Z] ^^^^^^^^^^^^^^^
[2025-09-10T10:51:48.397Z] ModuleNotFoundError: No module named 'cherrypy'
```