### PR TITLE
Fix broken symlinks on migration to Leap 16.0 (bsc#1250755)

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -1637,6 +1637,26 @@ fi
 %else
 %posttrans -n python-salt
 %endif
+
+%if %{with libalternatives}
+# restore symlinks to alts after migration from update-alternatives to alts
+# in cases where the old package flavor (based u-a) is removed in favor of
+# new python flavor (bsc#1250755).
+# i.a. python3-salt (3.6 using u-a) -> python313-salt (3.13 using alts)
+if [ -f /usr/bin/alts ]; then
+    for SALT_SCRIPT in salt-call salt-support spm; do
+        if [ ! -e "%{_bindir}/${SALT_SCRIPT}" ]; then
+            ln -sf alts "%{_bindir}/${SALT_SCRIPT}"
+        fi
+    done
+    for SALT_SCRIPT in salt salt-api salt-cloud salt-cp salt-key salt-master salt-minion salt-proxy salt-run salt-ssh salt-syndic zyppnotify; do
+        if [ ! -e "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}" ]; then
+            ln -sf ../../bin/alts "%{_exec_prefix}/libexec/salt/${SALT_SCRIPT}"
+        fi
+    done
+fi
+%endif
+
 # force re-generate a new thin.tgz
 rm -f %{_localstatedir}/cache/salt/master/thin/version
 rm -f %{_localstatedir}/cache/salt/minion/thin/version


### PR DESCRIPTION
This PR fixes an issue when migrating from Leap 15.6 to 16.0, where the Salt scripts end up with broken symlinks after the migration from `update-alternatives` to `alts`.

During the Leap migration, the `python3-salt` package (based on Python 3.6 and using "u-a") is replaced by `python313-salt` (based on Python 3.13 and using "alts").

The problem is that, when `update-alternatives --remove` is called to remove the alternative from the old python flavor package (`python3-salt`), as there is no other alternative for "u-a", then the "u-a" behavior is to remove also the script file (i.a. `/usr/bin/salt-call`,  or `/usr/libexec/salt/salt-minion`, etc). This removal happens at `%postun` stages after old package uninstallation (after the new package is installed).

Therefore this PR is adding a logic to fix possible broken symlinks at `%posttrans` stage (which runs after `%postun` stage).

Links: https://github.com/SUSE/spacewalk/issues/28545