### PR TITLE
Builds with py >313 require python-legacy-cgi

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -853,6 +853,7 @@ Recommends:     python-passlib
 
 %if 0%{?suse_version} >= 1600
 Requires:       %{python_module tornado}
+Requires:       %{python_module legacy-cgi}
 %else
 %if 0%{?singlespec_compat}
 Provides:       bundled(%{python_module tornado}) = 4.5.3


### PR DESCRIPTION
We depend on `cgi` in [0], which has been removed from python 3.13. We should be able to use `python-legacy-cgi` until upstream Salt removes the dependency (or probably until we switch to 3008)

[0] https://github.com/opensuse/salt/blob/master/salt/netapi/rest_tornado/saltnado.py#L188