### PR TITLE
Require python-legacy-cgi only for Python > 3.12

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -853,7 +853,9 @@ Recommends:     python-passlib
 
 %if 0%{?suse_version} >= 1600
 Requires:       %{python_module tornado}
+%if 0%{?python3_version_nodots} > 312
 Requires:       %{python_module legacy-cgi}
+%endif
 %else
 %if 0%{?singlespec_compat}
 Provides:       bundled(%{python_module tornado}) = 4.5.3


### PR DESCRIPTION
SLMicro 6.1 does not have `python311-legacy-cgi`, but `python-legacy-cgi` is only needed for Python 3.13 and newer.