### PR TITLE
Require Python dependencies only for used Python version

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -854,9 +854,9 @@ Recommends:     python-passlib
 %endif
 
 %if 0%{?suse_version} >= 1600
-Requires:       %{python_module tornado}
+Requires:       python-tornado
 %if 0%{?python3_version_nodots} > 312
-Requires:       %{python_module legacy-cgi}
+Requires:       python-legacy-cgi
 %endif
 %else
 %if 0%{?singlespec_compat}


### PR DESCRIPTION
Without this PR, the RPM requires all python versions of `tornado` and `legacy-cgi`, e.g. `python312-tornado` as well as `python313-tornado` for `python313-salt`.