### PR TITLE
Only Require python-pytest-subtests if SLE <= 1600.

### DIFF
--- a/salt/backport-3006.17-security-fixes-739.patch
+++ b/salt/backport-3006.17-security-fixes-739.patch
@@ -1,0 +1,1268 @@
+From 0ef57a3820d395ea6045c730db2e50e81f762382 Mon Sep 17 00:00:00 2001
+From: Alexander Graul <agraul@suse.com>
+Date: Mon, 24 Nov 2025 17:42:32 +0100
+Subject: [PATCH] Backport 3006.17 security fixes (#739)
+
+* Add minimum_auth_version to enforce all security
+
+CVE-2025-62349 A misbehaving minion could downgrade it's auth protocol
+version.
+
+(cherry picked from commit 1c76dfbc127c4b02f874ac852425f4288dfa7b73)
+
+* Use more secure default setting
+
+(cherry picked from commit 792f4985cce74541511b67a0b905bfe2a760184d)
+
+* Update compat test master config
+
+(cherry picked from commit 670c8ac4fd5da19f834e4b8877291dc11143b123)
+
+* Patch tornado for BDSA-2024-3438
+
+(cherry picked from commit e49357a6b0e49970bb455e8c268b24e7e1047548)
+
+* Patch tornado for BDSA-2024-3439
+
+(cherry picked from commit 644ba4474750031d64e770bb47b9dca144d1af24)
+
+* Patch tornado for BDSA-2024-9026
+
+(cherry picked from commit 867a627b702e1b4f9e07298b7ffce01edbbc414c)
+
+* Junos module yaml loader fix (CVE-2025-62348)
+
+Fixed unsafe YAML loader usage in junos execution module
+
+(cherry picked from commit c17fd645edef208233dcac855615fced69409a00)
+
+---------
+
+Co-authored-by: Daniel A. Wozniak <daniel.wozniak@broadcom.com>
+---
+ changelog/68377.fixed.md                      |   1 +
+ changelog/68379.fixed.md                      |   1 +
+ changelog/68383.fixed.md                      |   1 +
+ changelog/68467.fixed.md                      |   3 +
+ changelog/68469.fixed.md                      |   1 +
+ doc/ref/configuration/master.rst              |  61 ++++
+ salt/channel/server.py                        |  17 +-
+ salt/config/__init__.py                       |   3 +
+ salt/ext/tornado/curl_httpclient.py           |  14 +-
+ salt/ext/tornado/http1connection.py           |  61 +++-
+ salt/ext/tornado/httputil.py                  |  45 +--
+ salt/modules/junos.py                         |   2 +-
+ .../functional/channel/test_auth_downgrade.py | 316 ++++++++++++++++++
+ tests/pytests/scenarios/compat/conftest.py    |   2 +
+ tests/pytests/unit/channel/test_server.py     | 260 +++++++++++++-
+ .../unit/modules/test_junos_yaml_security.py  | 150 +++++++++
+ 16 files changed, 882 insertions(+), 56 deletions(-)
+ create mode 100644 changelog/68377.fixed.md
+ create mode 100644 changelog/68379.fixed.md
+ create mode 100644 changelog/68383.fixed.md
+ create mode 100644 changelog/68467.fixed.md
+ create mode 100644 changelog/68469.fixed.md
+ create mode 100644 tests/pytests/functional/channel/test_auth_downgrade.py
+ create mode 100644 tests/pytests/unit/modules/test_junos_yaml_security.py
+
+diff --git a/changelog/68377.fixed.md b/changelog/68377.fixed.md
+new file mode 100644
+index 00000000000..3e6d08b3c25
+--- /dev/null
++++ b/changelog/68377.fixed.md
+@@ -0,0 +1 @@
++Patch tornado for BDSA-2024-3438
+diff --git a/changelog/68379.fixed.md b/changelog/68379.fixed.md
+new file mode 100644
+index 00000000000..80f35f1dbbe
+--- /dev/null
++++ b/changelog/68379.fixed.md
+@@ -0,0 +1 @@
++Patch tornado for BDSA-2024-3439
+diff --git a/changelog/68383.fixed.md b/changelog/68383.fixed.md
+new file mode 100644
+index 00000000000..013c790784c
+--- /dev/null
++++ b/changelog/68383.fixed.md
+@@ -0,0 +1 @@
++Patch tornado for BDSA-2024-9026
+diff --git a/changelog/68467.fixed.md b/changelog/68467.fixed.md
+new file mode 100644
+index 00000000000..e569478e643
+--- /dev/null
++++ b/changelog/68467.fixed.md
+@@ -0,0 +1,3 @@
++Fixed authentication protocol version downgrade vulnerability (CVE-2025-62349) by adding `minimum_auth_version` configuration option (default: 3) to prevent minions from bypassing security features through protocol downgrade attacks.
++
++**BREAKING CHANGE:** The default value enforces authentication protocol version 3 or higher. If upgrading a deployment with older minions that do not support protocol v3, you must temporarily set `minimum_auth_version: 0` in the master configuration before upgrading the master, then upgrade all minions before removing this override.
+diff --git a/changelog/68469.fixed.md b/changelog/68469.fixed.md
+new file mode 100644
+index 00000000000..26ef26c1e51
+--- /dev/null
++++ b/changelog/68469.fixed.md
+@@ -0,0 +1 @@
++Fixed unsafe YAML loader usage in junos execution module (CVE-2025-62348)
+diff --git a/doc/ref/configuration/master.rst b/doc/ref/configuration/master.rst
+index a6022c94ee1..34b1c0e327e 100644
+--- a/doc/ref/configuration/master.rst
++++ b/doc/ref/configuration/master.rst
+@@ -2023,6 +2023,67 @@ The number of seconds between AES key rotations on the master.
+ 
+     publish_session: Default: 86400
+ 
++.. conf_master:: minimum_auth_version
++
++``minimum_auth_version``
++------------------------
++
++.. versionadded:: 3006.17,3007.9
++
++Default: ``3``
++
++Enforce a minimum authentication protocol version from minions connecting to the master.
++This setting protects against authentication downgrade attacks (CVE-2025-62349) where a
++malicious minion attempts to use an older, less secure authentication protocol version to
++bypass security features introduced in newer protocol versions.
++
++Authentication protocol versions and their security features:
++
++- **Version 0/1**: No message signing, no nonce, no security features (legacy, insecure)
++- **Version 2**: Message signing and nonce, but missing TTL validation, token validation,
++  and minion ID matching (partially secure)
++- **Version 3+**: Full security with message signing, nonce, TTL checks, token validation,
++  minion ID matching, and session keys (default and recommended)
++
++**Security-by-Default:**
++
++The default value of ``3`` enforces modern authentication protocol for maximum security.
++New installations automatically receive protection against authentication downgrade attacks
++without requiring additional configuration.
++
++**Important for Upgrades:**
++
++If you are upgrading a Salt deployment with minions running older versions that do not
++support authentication protocol version 3, you must temporarily lower this value during
++the upgrade process to prevent minions from being locked out.
++
++**Upgrade Path for Environments with Older Minions:**
++
++1. Before upgrading your Salt Master, set ``minimum_auth_version: 0`` in master config
++2. Upgrade your Salt Master to a version supporting ``minimum_auth_version``
++3. Restart the Salt Master
++4. Upgrade all minions to a version supporting authentication protocol v3+
++5. Remove the ``minimum_auth_version: 0`` override (or explicitly set to ``3``)
++6. Restart the Salt Master to enforce the secure default
++
++.. code-block:: yaml
++
++    # Default - enforces modern authentication protocol (secure)
++    minimum_auth_version: 3
++
++    # Temporary setting for upgrades with older minions
++    minimum_auth_version: 0
++
++.. warning::
++    Setting ``minimum_auth_version`` to a value higher than what your minions support
++    will prevent those minions from authenticating. Ensure all minions are upgraded
++    before increasing this value. Check your minion versions before changing this setting.
++
++.. note::
++    When a minion's authentication is rejected due to insufficient protocol version,
++    a warning message will be logged on the master including the minion ID and the
++    protocol version it attempted to use.
++
+ .. conf_master:: ssl
+ 
+ ``ssl``
+diff --git a/salt/channel/server.py b/salt/channel/server.py
+index a9151440c2b..7b6796e3b06 100644
+--- a/salt/channel/server.py
++++ b/salt/channel/server.py
+@@ -138,7 +138,22 @@ class ReqServerChannel:
+         ):
+             log.warn("bad load received on socket")
+             raise tornado.gen.Return("bad load")
+-        version = payload.get("version", 0)
++        try:
++            version = int(payload.get("version", 0))
++        except ValueError:
++            version = 0
++
++        # Enforce minimum authentication protocol version to prevent downgrade attacks
++        minimum_version = self.opts.get("minimum_auth_version", 0)
++        if minimum_version > 0 and version < minimum_version:
++            log.warning(
++                "Rejected authentication attempt using protocol version %d "
++                "(minimum required: %d)",
++                version,
++                minimum_version,
++            )
++            raise tornado.gen.Return("bad load")
++
+         try:
+             payload = self._decode_payload(payload, version)
+         except Exception as exc:  # pylint: disable=broad-except
+diff --git a/salt/config/__init__.py b/salt/config/__init__.py
+index 4f72f19f655..cfd55faf47e 100644
+--- a/salt/config/__init__.py
++++ b/salt/config/__init__.py
+@@ -1002,6 +1002,8 @@ VALID_OPTS = immutabletypes.freeze(
+         "request_server_aes_session": int,
+         "request_channel_timeout": int,
+         "request_channel_tries": int,
++        # Minimum authentication protocol version to accept from minions
++        "minimum_auth_version": int,
+     }
+ )
+ 
+@@ -1660,6 +1662,7 @@ DEFAULT_MASTER_OPTS = immutabletypes.freeze(
+         "fileserver_interval": 3600,
+         "request_server_aes_session": 0,
+         "request_server_ttl": 0,
++        "minimum_auth_version": 3,
+     }
+ )
+ 
+diff --git a/salt/ext/tornado/curl_httpclient.py b/salt/ext/tornado/curl_httpclient.py
+index 9e4133fd137..291709befaf 100644
+--- a/salt/ext/tornado/curl_httpclient.py
++++ b/salt/ext/tornado/curl_httpclient.py
+@@ -23,6 +23,7 @@ import collections
+ import functools
+ import logging
+ import pycurl  # type: ignore
++import re
+ import threading
+ import time
+ from io import BytesIO
+@@ -36,6 +37,7 @@ from salt.ext.tornado.httpclient import HTTPResponse, HTTPError, AsyncHTTPClient
+ 
+ curl_log = logging.getLogger('tornado.curl_httpclient')
+ 
++CR_OR_LF_RE = re.compile(b"\r|\n")
+ 
+ class CurlAsyncHTTPClient(AsyncHTTPClient):
+     def initialize(self, io_loop, max_clients=10, defaults=None):
+@@ -302,9 +304,15 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
+         if "Pragma" not in request.headers:
+             request.headers["Pragma"] = ""
+ 
+-        curl.setopt(pycurl.HTTPHEADER,
+-                    ["%s: %s" % (native_str(k), native_str(v))
+-                     for k, v in request.headers.get_all()])
++        encoded_headers = [
++            b"%s: %s"
++            % (native_str(k).encode("ASCII"), native_str(v).encode("ISO8859-1"))
++            for k, v in request.headers.get_all()
++        ]
++        for line in encoded_headers:
++            if CR_OR_LF_RE.search(line):
++                raise ValueError("Illegal characters in header (CR or LF): %r" % line)
++        curl.setopt(pycurl.HTTPHEADER, encoded_headers)
+ 
+         curl.setopt(pycurl.HEADERFUNCTION,
+                     functools.partial(self._curl_header_callback,
+diff --git a/salt/ext/tornado/http1connection.py b/salt/ext/tornado/http1connection.py
+index 7ed1078faa7..edec43dc761 100644
+--- a/salt/ext/tornado/http1connection.py
++++ b/salt/ext/tornado/http1connection.py
+@@ -34,6 +34,9 @@ from salt.ext.tornado import stack_context
+ from salt.ext.tornado.util import GzipDecompressor, PY3
+ 
+ 
++CR_OR_LF_RE = re.compile(b"\r|\n")
++
++
+ class _QuietException(Exception):
+     def __init__(self):
+         pass
+@@ -337,11 +340,10 @@ class HTTP1Connection(httputil.HTTPConnection):
+             self._request_start_line = start_line
+             lines.append(utf8('%s %s HTTP/1.1' % (start_line[0], start_line[1])))
+             # Client requests with a non-empty body must have either a
+-            # Content-Length or a Transfer-Encoding.
+             self._chunking_output = (
+                 start_line.method in ('POST', 'PUT', 'PATCH') and
+-                'Content-Length' not in headers and
+-                'Transfer-Encoding' not in headers)
++                'Content-Length' not in headers
++            )
+         else:
+             self._response_start_line = start_line
+             lines.append(utf8('HTTP/1.1 %d %s' % (start_line[1], start_line[2])))
+@@ -384,8 +386,8 @@ class HTTP1Connection(httputil.HTTPConnection):
+         else:
+             lines.extend(header_lines)
+         for line in lines:
+-            if b'\n' in line:
+-                raise ValueError('Newline in header: ' + repr(line))
++            if CR_OR_LF_RE.search(line):
++                raise ValueError("Illegal characters (CR or LF) in header: %r" % line)
+         future = None
+         if self.stream.closed():
+             future = self._write_future = Future()
+@@ -490,7 +492,7 @@ class HTTP1Connection(httputil.HTTPConnection):
+         if start_line.version == "HTTP/1.1":
+             return connection_header != "close"
+         elif ("Content-Length" in headers or
+-              headers.get("Transfer-Encoding", "").lower() == "chunked" or
++              is_transfer_encoding_chunked(headers) or
+               getattr(start_line, 'method', None) in ("HEAD", "GET")):
+             # start_line may be a request or response start line; only
+             # the former has a method attribute.
+@@ -527,12 +529,6 @@ class HTTP1Connection(httputil.HTTPConnection):
+ 
+     def _read_body(self, code, headers, delegate):
+         if "Content-Length" in headers:
+-            if "Transfer-Encoding" in headers:
+-                # Response cannot contain both Content-Length and
+-                # Transfer-Encoding headers.
+-                # http://tools.ietf.org/html/rfc7230#section-3.3.3
+-                raise httputil.HTTPInputError(
+-                    "Response with both Transfer-Encoding and Content-Length")
+             if "," in headers["Content-Length"]:
+                 # Proxies sometimes cause Content-Length headers to get
+                 # duplicated.  If all the values are identical then we can
+@@ -556,20 +552,23 @@ class HTTP1Connection(httputil.HTTPConnection):
+         else:
+             content_length = None
+ 
++        is_chunked = is_transfer_encoding_chunked(headers)
++
+         if code == 204:
+             # This response code is not allowed to have a non-empty body,
+             # and has an implicit length of zero instead of read-until-close.
+             # http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.3
+-            if ("Transfer-Encoding" in headers or
+-                    content_length not in (None, 0)):
++            if is_chunked or content_length not in (None, 0):
+                 raise httputil.HTTPInputError(
+                     "Response with code %d should not have body" % code)
+             content_length = 0
+ 
++        if is_chunked:
++            return self._read_chunked_body(delegate)
++
+         if content_length is not None:
+             return self._read_fixed_body(content_length, delegate)
+-        if headers.get("Transfer-Encoding", "").lower() == "chunked":
+-            return self._read_chunked_body(delegate)
++
+         if self.is_client:
+             return self._read_body_until_close(delegate)
+         return None
+@@ -741,3 +740,33 @@ class HTTP1ServerConnection(object):
+                 yield gen.moment
+         finally:
+             delegate.on_close(self)
++
++
++def is_transfer_encoding_chunked(headers: httputil.HTTPHeaders) -> bool:
++    """Returns true if the headers specify Transfer-Encoding: chunked.
++
++    Raise httputil.HTTPInputError if any other transfer encoding is used.
++    """
++    # Note that transfer-encoding is an area in which postel's law can lead
++    # us astray. If a proxy and a backend server are liberal in what they accept,
++    # but accept slightly different things, this can lead to mismatched framing
++    # and request smuggling issues. Therefore we are as strict as possible here
++    # (even technically going beyond the requirements of the RFCs: a value of
++    # ",chunked" is legal but doesn't appear in practice for legitimate traffic)
++    if "Transfer-Encoding" not in headers:
++        return False
++    if "Content-Length" in headers:
++        # Message cannot contain both Content-Length and
++        # Transfer-Encoding headers.
++        # http://tools.ietf.org/html/rfc7230#section-3.3.3
++        raise httputil.HTTPInputError(
++            "Message with both Transfer-Encoding and Content-Length"
++        )
++    if headers["Transfer-Encoding"].lower() == "chunked":
++        return True
++    # We do not support any transfer-encodings other than chunked, and we do not
++    # expect to add any support because the concept of transfer-encoding has
++    # been removed in HTTP/2.
++    raise httputil.HTTPInputError(
++        "Unsupported Transfer-Encoding %s" % headers["Transfer-Encoding"]
++    )
+diff --git a/salt/ext/tornado/httputil.py b/salt/ext/tornado/httputil.py
+index 0968c4a3004..4866b0c9911 100644
+--- a/salt/ext/tornado/httputil.py
++++ b/salt/ext/tornado/httputil.py
+@@ -68,6 +68,9 @@ except ImportError:
+     pass
+ 
+ 
++# To be used with str.strip() and related methods.
++HTTP_WHITESPACE = " \t"
++
+ # RFC 7230 section 3.5: a recipient MAY recognize a single LF as a line
+ # terminator and ignore any preceding CR.
+ _CRLF_RE = re.compile(r"\r?\n")
+@@ -188,12 +191,12 @@ class HTTPHeaders(MutableMapping):
+         """
+         if line[0].isspace():
+             # continuation of a multi-line header
+-            new_part = " " + line.lstrip()
++            new_part = " " + line.lstrip(HTTP_WHITESPACE)
+             self._as_list[self._last_key][-1] += new_part
+             self._dict[self._last_key] += new_part
+         else:
+             name, value = line.split(":", 1)
+-            self.add(name, value.strip())
++            self.add(name, value.strip(HTTP_WHITESPACE))
+ 
+     @classmethod
+     def parse(cls, headers):
+@@ -972,15 +975,20 @@ def split_host_and_port(netloc):
+     return (host, port)
+ 
+ 
+-_OctalPatt = re.compile(r"\\[0-3][0-7][0-7]")
+-_QuotePatt = re.compile(r"[\\].")
+-_nulljoin = "".join
++_unquote_sub = re.compile(r"\\(?:([0-3][0-7][0-7])|(.))").sub
++
++
++def _unquote_replace(m):
++    if m[1]:
++        return chr(int(m[1], 8))
++    else:
++        return m[2]
+ 
+ 
+ def _unquote_cookie(str):
+     """Handle double quotes and escaping in cookie values.
+ 
+-    This method is copied verbatim from the Python 3.5 standard
++    This method is copied verbatim from the Python 3.13 standard
+     library (http.cookies._unquote) so we don't have to depend on
+     non-public interfaces.
+     """
+@@ -1001,30 +1009,7 @@ def _unquote_cookie(str):
+     #    \012 --> \n
+     #    \"   --> "
+     #
+-    i = 0
+-    n = len(str)
+-    res = []
+-    while 0 <= i < n:
+-        o_match = _OctalPatt.search(str, i)
+-        q_match = _QuotePatt.search(str, i)
+-        if not o_match and not q_match:  # Neither matched
+-            res.append(str[i:])
+-            break
+-        # else:
+-        j = k = -1
+-        if o_match:
+-            j = o_match.start(0)
+-        if q_match:
+-            k = q_match.start(0)
+-        if q_match and (not o_match or k < j):  # QuotePatt matched
+-            res.append(str[i:k])
+-            res.append(str[k + 1])
+-            i = k + 2
+-        else:  # OctalPatt matched
+-            res.append(str[i:j])
+-            res.append(chr(int(str[j + 1 : j + 4], 8)))
+-            i = j + 4
+-    return _nulljoin(res)
++    return _unquote_sub(_unquote_replace, s)
+ 
+ 
+ def parse_cookie(cookie):
+diff --git a/salt/modules/junos.py b/salt/modules/junos.py
+index 33f25080e1d..1843ae637f1 100644
+--- a/salt/modules/junos.py
++++ b/salt/modules/junos.py
+@@ -1858,7 +1858,7 @@ def get_table(
+             try:
+                 with salt.utils.files.fopen(file_loc) as fp:
+                     ret["table"] = yaml.load(
+-                        fp.read(), Loader=yamlordereddictloader.Loader
++                        fp.read(), Loader=yamlordereddictloader.SafeLoader
+                     )
+                     globals().update(FactoryLoader().load(ret["table"]))
+             except OSError as err:
+diff --git a/tests/pytests/functional/channel/test_auth_downgrade.py b/tests/pytests/functional/channel/test_auth_downgrade.py
+new file mode 100644
+index 00000000000..09fcd38bd79
+--- /dev/null
++++ b/tests/pytests/functional/channel/test_auth_downgrade.py
+@@ -0,0 +1,316 @@
++"""
++Functional tests for authentication version downgrade attacks.
++
++These tests demonstrate the vulnerability where a malicious minion can
++downgrade its authentication protocol version to bypass security features.
++"""
++
++import ctypes
++import multiprocessing
++import pathlib
++
++import pytest
++
++import salt.channel.client
++import salt.channel.server
++import salt.config
++import salt.crypt
++import salt.daemons.masterapi
++import salt.ext.tornado.gen
++import salt.ext.tornado.ioloop
++import salt.master
++import salt.payload
++import salt.utils.event
++import salt.utils.files
++import salt.utils.platform
++import salt.utils.process
++import salt.utils.stringutils
++from salt.master import SMaster
++
++pytestmark = [
++    pytest.mark.skip_on_spawning_platform(
++        reason="These tests are currently broken on spawning platforms. Need to be rewritten.",
++    ),
++    pytest.mark.timeout_unless_on_windows(120),
++]
++
++
++@pytest.fixture
++def channel_minion_id():
++    return "test-minion-downgrade"
++
++
++@pytest.fixture
++def auth_pki_dir(tmp_path):
++    """Setup PKI directory structure for functional auth tests."""
++    if salt.utils.platform.is_darwin():
++        # To avoid 'OSError: AF_UNIX path too long'
++        _root_dir = pathlib.Path("/tmp").resolve() / tmp_path.name
++        root_dir = _root_dir
++    else:
++        root_dir = tmp_path
++
++    master_pki = root_dir / "master_pki"
++    minion_pki = root_dir / "minion_pki"
++
++    master_pki.mkdir(parents=True)
++    minion_pki.mkdir(parents=True)
++    (master_pki / "minions").mkdir()
++    (master_pki / "minions_pre").mkdir()
++    (master_pki / "minions_rejected").mkdir()
++    (master_pki / "minions_denied").mkdir()
++
++    # Generate keys
++    salt.crypt.gen_keys(str(master_pki), "master", 4096)
++    salt.crypt.gen_keys(str(minion_pki), "minion", 4096)
++
++    yield root_dir
++
++    if salt.utils.platform.is_darwin():
++        import shutil
++
++        shutil.rmtree(str(root_dir), ignore_errors=True)
++
++
++def _create_functional_master_opts(
++    auth_pki_dir, channel_minion_id, minimum_auth_version=0
++):
++    """Helper to create master configuration with specified minimum_auth_version."""
++    opts = {
++        "master_uri": "tcp://127.0.0.1:44506",
++        "interface": "127.0.0.1",
++        "ret_port": 44506,
++        "ipv6": False,
++        "sock_dir": str(auth_pki_dir / "sock"),
++        "cachedir": str(auth_pki_dir / "cache"),
++        "pki_dir": str(auth_pki_dir / "master_pki"),
++        "id": "master",
++        "__role": "master",
++        "transport": "zeromq",
++        "keysize": 4096,
++        "max_minions": 0,
++        "auto_accept": True,
++        "open_mode": False,
++        "key_pass": None,
++        "publish_port": 44505,
++        "auth_mode": 1,
++        "auth_events": True,
++        "publish_session": 86400,
++        "request_server_ttl": 300,  # 5 minutes
++        "worker_threads": 1,
++        "cluster_id": None,
++        "master_sign_pubkey": False,
++        "sign_pub_messages": False,
++        "minimum_auth_version": minimum_auth_version,
++    }
++    (auth_pki_dir / "sock").mkdir(exist_ok=True)
++    (auth_pki_dir / "cache").mkdir(exist_ok=True)
++    (auth_pki_dir / "cache" / "sessions").mkdir(exist_ok=True)
++
++    # Accept the minion key
++    minion_pub = auth_pki_dir / "minion_pki" / "minion.pub"
++    master_minions = auth_pki_dir / "master_pki" / "minions" / channel_minion_id
++    if minion_pub.exists():
++        with salt.utils.files.fopen(str(minion_pub)) as src:
++            with salt.utils.files.fopen(str(master_minions), "w") as dst:
++                dst.write(src.read())
++
++    return opts
++
++
++@pytest.fixture
++def functional_master_opts(auth_pki_dir, channel_minion_id):
++    """Master configuration for functional tests (default: minimum_auth_version=3)."""
++    return _create_functional_master_opts(
++        auth_pki_dir, channel_minion_id, minimum_auth_version=3
++    )
++
++
++@pytest.fixture
++def functional_minion_opts(auth_pki_dir, functional_master_opts, channel_minion_id):
++    """Minion configuration for functional tests."""
++    return {
++        "master_uri": "tcp://127.0.0.1:44506",
++        "interface": "127.0.0.1",
++        "ret_port": 44506,
++        "ipv6": False,
++        "sock_dir": str(functional_master_opts["sock_dir"]),
++        "pki_dir": str(auth_pki_dir / "minion_pki"),
++        "id": channel_minion_id,
++        "__role": "minion",
++        "transport": "zeromq",
++        "keysize": 4096,
++        "master_port": 44506,
++        "master_ip": "127.0.0.1",
++    }
++
++
++@pytest.mark.parametrize(
++    "minimum_auth_version,attack_version,should_pass",
++    [
++        pytest.param(
++            0,
++            0,
++            False,
++            marks=pytest.mark.xfail(
++                reason="Vulnerable: minimum_auth_version=0 allows all versions",
++                strict=True,
++            ),
++        ),
++        pytest.param(
++            0,
++            1,
++            False,
++            marks=pytest.mark.xfail(
++                reason="Vulnerable: minimum_auth_version=0 allows all versions",
++                strict=True,
++            ),
++        ),
++        pytest.param(
++            0,
++            2,
++            False,
++            marks=pytest.mark.xfail(
++                reason="Vulnerable: minimum_auth_version=0 allows all versions",
++                strict=True,
++            ),
++        ),
++        pytest.param(1, 0, True, id="v1-rejects-v0"),
++        pytest.param(
++            1,
++            1,
++            False,
++            marks=pytest.mark.xfail(
++                reason="Vulnerable: minimum_auth_version=1 allows v1", strict=True
++            ),
++        ),
++        pytest.param(
++            1,
++            2,
++            False,
++            marks=pytest.mark.xfail(
++                reason="Vulnerable: minimum_auth_version=1 allows v2", strict=True
++            ),
++        ),
++        pytest.param(2, 0, True, id="v2-rejects-v0"),
++        pytest.param(2, 1, True, id="v2-rejects-v1"),
++        pytest.param(
++            2,
++            2,
++            False,
++            marks=pytest.mark.xfail(
++                reason="Vulnerable: minimum_auth_version=2 allows v2", strict=True
++            ),
++        ),
++        pytest.param(3, 0, True, id="v3-rejects-v0"),
++        pytest.param(3, 1, True, id="v3-rejects-v1"),
++        pytest.param(3, 2, True, id="v3-rejects-v2-SECURE"),
++    ],
++)
++async def test_replay_attack_via_version_downgrade(
++    auth_pki_dir,
++    functional_minion_opts,
++    channel_minion_id,
++    minimum_auth_version,
++    attack_version,
++    should_pass,
++):
++    """
++    REGRESSION TEST: CVE-2025-62349 - Authentication Protocol Version Downgrade Attack
++
++    This parameterized test verifies that version downgrade attacks are prevented
++    based on the minimum_auth_version configuration.
++
++    Attack Scenario:
++    A malicious or compromised minion attempts to authenticate using an older protocol
++    version to bypass security features introduced in newer versions (token validation,
++    TTL checks, ID matching, session keys). This allows the attacker to impersonate
++    other minions or maintain persistent unauthorized access.
++
++    Test Matrix:
++    - minimum_auth_version=0: VULNERABLE - accepts all versions (xfail)
++    - minimum_auth_version=1: Partially secure - rejects v0 only
++    - minimum_auth_version=2: Partially secure - rejects v0, v1
++    - minimum_auth_version=3: SECURE - rejects v0, v1, v2 (default and recommended)
++
++    This test uses xfail for vulnerable configurations to document the security risk.
++    """
++    # Create master opts with the specified minimum_auth_version
++    master_opts = _create_functional_master_opts(
++        auth_pki_dir, channel_minion_id, minimum_auth_version
++    )
++
++    # Setup master secrets
++    SMaster.secrets["aes"] = {
++        "secret": multiprocessing.Array(
++            ctypes.c_char,
++            salt.utils.stringutils.to_bytes(salt.crypt.Crypticle.generate_key_string()),
++        ),
++        "serial": multiprocessing.Value(ctypes.c_longlong, lock=False),
++    }
++
++    # Create server channel
++    server_channel = salt.channel.server.ReqServerChannel.factory(master_opts)
++    server_channel.auto_key = salt.daemons.masterapi.AutoKey(master_opts)
++    server_channel.cache_cli = False
++    server_channel.event = salt.utils.event.get_master_event(
++        master_opts, master_opts["sock_dir"], listen=False
++    )
++    server_channel.master_key = salt.crypt.MasterKeys(master_opts)
++
++    try:
++        # Verify the configuration
++        assert (
++            master_opts.get("minimum_auth_version") == minimum_auth_version
++        ), f"Master should have minimum_auth_version={minimum_auth_version}"
++
++        # Read minion public key
++        with salt.utils.files.fopen(
++            str(auth_pki_dir / "minion_pki" / "minion.pub"), "r"
++        ) as fp:
++            pub_key = fp.read()
++
++        # Create auth load for the attack version
++        load = {
++            "cmd": "_auth",
++            "id": channel_minion_id,
++            "pub": pub_key,
++        }
++
++        # Add nonce for version 2+
++        if attack_version >= 2:
++            load["nonce"] = "test-nonce"
++
++        # Create payload for handle_message
++        payload = {"enc": "clear", "load": load, "version": attack_version}
++
++        # Call handle_message which will enforce minimum_auth_version
++        ret = await server_channel.handle_message(payload)
++
++        # Check if attack was blocked
++        if should_pass:
++            # Attack should be blocked (old version rejected)
++            # With proper minimum_auth_version, handle_message returns "bad load"
++            assert ret == "bad load", (
++                f"Expected 'bad load' for rejected version {attack_version} "
++                f"with minimum {minimum_auth_version}"
++            )
++        else:
++            # Vulnerable: attack succeeds (old version accepted)
++            # Assert that auth SHOULD be rejected (but it won't be - causing xfail)
++            # This assertion will FAIL for vulnerable configs, documenting the security issue
++            assert ret == "bad load", (
++                f"SECURITY ISSUE: Version {attack_version} was accepted "
++                f"with minimum_auth_version={minimum_auth_version}"
++            )
++
++    finally:
++        server_channel.close()
++        if "aes" in SMaster.secrets:
++            SMaster.secrets.pop("aes")
++
++
++# Note: Additional functional tests for ID mismatch and token bypass
++# have been covered in the unit tests. This single functional test
++# demonstrates the replay attack scenario which is the most critical
++# end-to-end attack vector.
+diff --git a/tests/pytests/scenarios/compat/conftest.py b/tests/pytests/scenarios/compat/conftest.py
+index 29d58354abc..eb28de2a3ba 100644
+--- a/tests/pytests/scenarios/compat/conftest.py
++++ b/tests/pytests/scenarios/compat/conftest.py
+@@ -134,6 +134,8 @@ def salt_master(
+         "log_level_logfile": "quiet",
+         # We also want to scrutinize the key acceptance
+         "open_mode": False,
++        # Allow older minion versions to connect (they don't support auth protocol v3)
++        "minimum_auth_version": 0,
+     }
+ 
+     # We need to copy the extension modules into the new master root_dir or
+diff --git a/tests/pytests/unit/channel/test_server.py b/tests/pytests/unit/channel/test_server.py
+index 806b82bbaaf..5ebd5ef83bc 100644
+--- a/tests/pytests/unit/channel/test_server.py
++++ b/tests/pytests/unit/channel/test_server.py
+@@ -1,16 +1,25 @@
++import ctypes
++import multiprocessing
+ import time
++import uuid
+ 
+ import pytest
++import tornado.gen
+ 
+ import salt.channel.server as server
+-import tornado.gen
++import salt.crypt
++import salt.daemons.masterapi
++import salt.master
++import salt.payload
++import salt.utils.event
++import salt.utils.files
++import salt.utils.stringutils
++from salt.master import SMaster
+ from tests.support.mock import MagicMock, patch
+ 
+ 
+ def test__auth_cmd_stats_passing(master_opts):
+-    master_opts.update(
+-        {"master_stats": True}
+-    )
++    master_opts.update({"master_stats": True})
+     req_server_channel = server.ReqServerChannel(master_opts, None)
+ 
+     fake_ret = {"enc": "clear", "load": b"FAKELOAD"}
+@@ -25,7 +34,7 @@ def test__auth_cmd_stats_passing(master_opts):
+     with patch.object(req_server_channel, "_auth", _auth_mock):
+         req_server_channel.payload_handler = MagicMock(return_value=future)
+         req_server_channel.handle_message(
+-            {"enc": "clear", "load": {"cmd": "_auth", "id": "minion"}}
++            {"enc": "clear", "load": {"cmd": "_auth", "id": "minion"}, "version": 3}
+         )
+         cur_time = time.time()
+         req_server_channel.payload_handler.assert_called_once()
+@@ -80,3 +89,244 @@ def test_req_server_validate_token_removes_token_id_traversal(root_dir):
+     }
+     assert reqsrv.validate_token(payload) is False
+     assert "tok" not in payload["load"]
++
++
++# ============================================================================
++# Auth Version Downgrade Attack Regression Tests
++# ============================================================================
++
++
++@pytest.fixture
++def pki_dir(tmp_path):
++    """Setup PKI directory structure for auth tests."""
++    master_pki = tmp_path / "master"
++    minion_pki = tmp_path / "minion"
++
++    master_pki.mkdir()
++    minion_pki.mkdir()
++    (master_pki / "minions").mkdir()
++    (master_pki / "minions_pre").mkdir()
++    (master_pki / "minions_rejected").mkdir()
++    (master_pki / "minions_denied").mkdir()
++
++    # Generate master keys
++    salt.crypt.gen_keys(str(master_pki), "master", 4096)
++
++    # Generate minion keys
++    salt.crypt.gen_keys(str(minion_pki), "minion", 4096)
++
++    return tmp_path
++
++
++@pytest.fixture
++def auth_master_opts(pki_dir, tmp_path):
++    """Master configuration for auth tests."""
++    opts = {
++        "master_uri": "tcp://127.0.0.1:4506",
++        "interface": "127.0.0.1",
++        "ret_port": 4506,
++        "ipv6": False,
++        "sock_dir": str(tmp_path / "sock"),
++        "cachedir": str(tmp_path / "cache"),
++        "pki_dir": str(pki_dir / "master"),
++        "id": "master",
++        "__role": "master",
++        "keysize": 4096,
++        "max_minions": 0,
++        "auto_accept": False,
++        "open_mode": False,
++        "key_pass": None,
++        "publish_port": 4505,
++        "auth_mode": 1,
++        "auth_events": True,
++        "publish_session": 86400,
++        "request_server_ttl": 300,  # 5 minutes
++        "master_sign_pubkey": False,
++        "sign_pub_messages": False,
++        "cluster_id": None,
++        "transport": "zeromq",
++        "minimum_auth_version": 3,  # Enforce version 3+ for security
++    }
++    (tmp_path / "sock").mkdir(exist_ok=True)
++    (tmp_path / "cache").mkdir(exist_ok=True)
++    (tmp_path / "cache" / "sessions").mkdir(exist_ok=True)
++    return opts
++
++
++@pytest.fixture
++def auth_minion_opts(pki_dir, auth_master_opts):
++    """Minion configuration for auth tests."""
++    return {
++        "master_uri": "tcp://127.0.0.1:4506",
++        "interface": "127.0.0.1",
++        "ret_port": 4506,
++        "ipv6": False,
++        "sock_dir": str(auth_master_opts["sock_dir"]),
++        "pki_dir": str(pki_dir / "minion"),
++        "id": "test-minion",
++        "__role": "minion",
++        "keysize": 4096,
++    }
++
++
++@pytest.fixture
++def setup_accepted_minion(pki_dir, auth_minion_opts, auth_master_opts):
++    """
++    Setup a pre-accepted minion by copying its public key to master's
++    minions directory.
++    """
++    minion_pub = pki_dir / "minion" / "minion.pub"
++    master_minions_dir = pki_dir / "master" / "minions"
++    accepted_key = master_minions_dir / auth_minion_opts["id"]
++
++    # Copy minion public key to master's accepted keys
++    with salt.utils.files.fopen(str(minion_pub)) as src:
++        with salt.utils.files.fopen(str(accepted_key), "w") as dst:
++            dst.write(src.read())
++
++    return accepted_key
++
++
++@pytest.fixture
++def req_server(auth_master_opts):
++    """Create a ReqServerChannel instance for testing."""
++    # Setup master secrets
++    SMaster.secrets["aes"] = {
++        "secret": multiprocessing.Array(
++            ctypes.c_char,
++            salt.utils.stringutils.to_bytes(salt.crypt.Crypticle.generate_key_string()),
++        ),
++        "reload": salt.crypt.Crypticle.generate_key_string,
++    }
++
++    server_channel = server.ReqServerChannel.factory(auth_master_opts)
++    server_channel.auto_key = salt.daemons.masterapi.AutoKey(auth_master_opts)
++    server_channel.cache_cli = False
++    server_channel.event = salt.utils.event.get_master_event(
++        auth_master_opts, auth_master_opts["sock_dir"], listen=False
++    )
++    server_channel.master_key = salt.crypt.MasterKeys(auth_master_opts)
++
++    yield server_channel
++
++    server_channel.close()
++    if "aes" in SMaster.secrets:
++        SMaster.secrets.pop("aes")
++
++
++async def test_auth_version_downgrade_v3_to_v0(
++    pki_dir, auth_minion_opts, req_server, setup_accepted_minion
++):
++    """
++    REGRESSION TEST: CVE-2025-62349 - Auth Version Downgrade Attack
++
++    Test that the master rejects authentication attempts using protocol version 0
++    when minimum_auth_version is set to 3.
++
++    This prevents a malicious or compromised minion from using an older protocol
++    version to bypass security features introduced in version 3+ (token validation,
++    TTL checks, ID matching, session keys).
++
++    The test verifies that the minimum_auth_version enforcement works at the initial
++    authentication stage, preventing minions from establishing low-version sessions.
++    """
++    # Read minion public key
++    with salt.utils.files.fopen(str(pki_dir / "minion" / "minion.pub"), "r") as fp:
++        pub_key = fp.read()
++
++    # Simulate version 0 auth load (no nonce, no signing)
++    load_v0 = {
++        "cmd": "_auth",
++        "id": auth_minion_opts["id"],
++        "pub": pub_key,
++    }
++
++    # Create payload for handle_message (version 0)
++    payload = {"enc": "clear", "load": load_v0, "version": 0}
++
++    # Call handle_message which will enforce minimum_auth_version
++    ret = await req_server.handle_message(payload)
++
++    # REGRESSION TEST: Version 0 should be REJECTED
++    # With minimum_auth_version=3, version 0 should return "bad load"
++    assert ret == "bad load", "Expected 'bad load' for rejected version 0 auth"
++
++
++@pytest.mark.parametrize("downgrade_version", [0, 1, 2])
++async def test_auth_version_downgrade_from_v3(
++    pki_dir, auth_minion_opts, req_server, setup_accepted_minion, downgrade_version
++):
++    """
++    REGRESSION TEST: CVE-2025-62349 - Auth Version Downgrade Attack (Parametrized)
++
++    Test that the master rejects authentication attempts using protocol versions
++    0, 1, or 2 when minimum_auth_version is set to 3.
++
++    This prevents malicious or compromised minions from using older protocol
++    versions to bypass security features:
++    - v0/v1: No message signing, no nonce
++    - v2: Message signing but no token validation, no TTL checks, no ID matching
++    - v3+: Full security (token validation, TTL, ID matching, session keys)
++
++    The test verifies that minimum_auth_version enforcement prevents minions from
++    establishing low-version sessions that would allow them to bypass security
++    controls and potentially impersonate other minions or maintain unauthorized access.
++    """
++    with salt.utils.files.fopen(str(pki_dir / "minion" / "minion.pub"), "r") as fp:
++        pub_key = fp.read()
++
++    load = {
++        "cmd": "_auth",
++        "id": auth_minion_opts["id"],
++        "pub": pub_key,
++    }
++
++    # Add nonce for v2+ (but not for v0/v1)
++    if downgrade_version >= 2:
++        load["nonce"] = uuid.uuid4().hex
++
++    # Create payload for handle_message
++    payload = {"enc": "clear", "load": load, "version": downgrade_version}
++
++    # Call handle_message which will enforce minimum_auth_version
++    ret = await req_server.handle_message(payload)
++
++    # REGRESSION TEST: Old versions should be REJECTED
++    # With minimum_auth_version=3, versions 0, 1, 2 should return "bad load"
++    assert (
++        ret == "bad load"
++    ), f"Expected 'bad load' for rejected version {downgrade_version} auth"
++
++
++def test_handle_message_version_extraction(auth_master_opts):
++    """
++    REGRESSION TEST: CVE-2025-62349 - Version Extraction from Untrusted Payload
++
++    Test that the master should have minimum_auth_version configured.
++
++    EXPECTED BEHAVIOR:
++    - Master opts should have minimum_auth_version set
++    - The commented code at salt/channel/server.py:144-145 should be enabled
++
++    CURRENT BEHAVIOR (VULNERABLE):
++    - Test will FAIL - minimum_auth_version is not in opts
++    - After fix is implemented, this test will PASS
++    """
++    # The current code at salt/channel/server.py:139-145 shows:
++    # version = payload.get("version", 0)
++    # #if version < self.opts["minimum_auth_version"]:
++    # #    raise salt.ext.tornado.gen.Return("bad load")
++
++    # REGRESSION TEST: Verify minimum_auth_version exists in opts
++    # Currently this will FAIL because the option doesn't exist
++    assert (
++        "minimum_auth_version" in auth_master_opts
++    ), "Expected minimum_auth_version to be configured in master opts"
++    assert (
++        auth_master_opts["minimum_auth_version"] >= 3
++    ), "Expected minimum auth version to be at least 3"
++
++
++# Note: The remaining security bypasses (token, TTL, ID mismatch, session keys)
++# are already tested via the parametrized downgrade tests above and the
++# functional tests. The key regression test is ensuring old versions are rejected.
+diff --git a/tests/pytests/unit/modules/test_junos_yaml_security.py b/tests/pytests/unit/modules/test_junos_yaml_security.py
+new file mode 100644
+index 00000000000..5213480eb32
+--- /dev/null
++++ b/tests/pytests/unit/modules/test_junos_yaml_security.py
+@@ -0,0 +1,150 @@
++"""
++Regression test for unsafe YAML loading in junos module.
++
++This test ensures that the junos.get_table() function uses a safe YAML loader
++and does not allow arbitrary code execution.
++
++CVE/Security Issue: The junos module was using yamlordereddictloader.Loader
++which extends yaml.Loader (unsafe). It should use yamlordereddictloader.SafeLoader.
++"""
++
++import pytest
++import yaml
++
++try:
++    import yamlordereddictloader
++
++    HAS_YAMLORDEREDDICTLOADER = True
++except ImportError:
++    HAS_YAMLORDEREDDICTLOADER = False
++
++
++pytestmark = [
++    pytest.mark.skipif(
++        not HAS_YAMLORDEREDDICTLOADER,
++        reason="The yamlordereddictloader module is required",
++    ),
++]
++
++
++def test_junos_module_uses_safe_yaml_loader():
++    """
++    Regression test to ensure junos module uses SafeLoader, not Loader.
++
++    This test will:
++    - FAIL if salt/modules/junos.py uses yamlordereddictloader.Loader (UNSAFE)
++    - PASS if salt/modules/junos.py uses yamlordereddictloader.SafeLoader (SAFE)
++    """
++    import inspect
++
++    import salt.modules.junos as junos
++
++    # Get the source code of the get_table function
++    source = inspect.getsource(junos.get_table)
++
++    # Check that SafeLoader is used, not Loader
++    if "yamlordereddictloader.Loader" in source and "SafeLoader" not in source.replace(
++        "yamlordereddictloader.Loader", ""
++    ):
++        pytest.fail(
++            "SECURITY VULNERABILITY: junos.get_table() uses yamlordereddictloader.Loader!\n\n"
++            "The unsafe Loader can execute arbitrary Python code from YAML files.\n\n"
++            "FIX: Change yamlordereddictloader.Loader to yamlordereddictloader.SafeLoader\n"
++            "in salt/modules/junos.py (around line 1861)"
++        )
++
++    # Verify SafeLoader is actually used
++    assert "yamlordereddictloader.SafeLoader" in source, (
++        "Expected to find yamlordereddictloader.SafeLoader in junos.get_table(). "
++        "Make sure the safe loader is being used."
++    )
++
++
++def test_yamlordereddictloader_safeloader_blocks_code_execution():
++    """
++    Test that yamlordereddictloader.SafeLoader blocks arbitrary code execution.
++
++    This demonstrates the correct, secure behavior that should be used.
++    """
++    # Malicious YAML attempting to execute os.system
++    malicious_yaml = "!!python/object/apply:os.system ['echo this should not execute']"
++
++    # SafeLoader should reject this and raise ConstructorError
++    with pytest.raises(yaml.constructor.ConstructorError):
++        yaml.load(malicious_yaml, Loader=yamlordereddictloader.SafeLoader)
++
++
++def test_yamlordereddictloader_loader_inheritance():
++    """
++    Verify the inheritance chain showing why Loader is unsafe.
++    """
++    # yamlordereddictloader.Loader extends yaml.Loader (UNSAFE)
++    assert issubclass(
++        yamlordereddictloader.Loader, yaml.Loader
++    ), "yamlordereddictloader.Loader should extend yaml.Loader (unsafe)"
++
++    # yamlordereddictloader.SafeLoader extends yaml.SafeLoader (SAFE)
++    assert issubclass(
++        yamlordereddictloader.SafeLoader, yaml.SafeLoader
++    ), "yamlordereddictloader.SafeLoader should extend yaml.SafeLoader (safe)"
++
++
++def test_ordered_dict_functionality_with_safeloader():
++    """
++    Verify that SafeLoader still provides OrderedDict functionality.
++
++    This ensures that switching to SafeLoader doesn't break the intended
++    functionality of maintaining key order.
++    """
++    test_yaml = """
++TableTest:
++    key1: value1
++    key2: value2
++    key3: value3
++"""
++
++    # Load with SafeLoader
++    result = yaml.load(test_yaml, Loader=yamlordereddictloader.SafeLoader)
++
++    # Verify it loaded successfully
++    assert "TableTest" in result
++    assert result["TableTest"]["key1"] == "value1"
++
++    # Verify it returns OrderedDict (the whole point of yamlordereddictloader)
++    from collections import OrderedDict
++
++    assert isinstance(result, OrderedDict) or isinstance(result, dict)
++    assert isinstance(result["TableTest"], OrderedDict) or isinstance(
++        result["TableTest"], dict
++    )
++
++
++def test_compare_unsafe_vs_safe_loader():
++    """
++    Direct comparison showing the difference between unsafe and safe loaders.
++    """
++    # Safe YAML that should work with both loaders
++    safe_yaml = """
++config:
++    host: example.com
++    port: 8080
++    enabled: true
++"""
++
++    # Load with both loaders - should work fine
++    result_unsafe = yaml.load(safe_yaml, Loader=yamlordereddictloader.Loader)
++    result_safe = yaml.load(safe_yaml, Loader=yamlordereddictloader.SafeLoader)
++
++    # Both should produce the same result for safe YAML
++    assert result_unsafe == result_safe
++
++    # Malicious YAML with Python object constructor
++    malicious_yaml = "!!python/object/apply:os.system ['ls']"
++
++    # Safe Loader will raise an exception (correct behavior)
++    with pytest.raises(yaml.constructor.ConstructorError):
++        yaml.load(malicious_yaml, Loader=yamlordereddictloader.SafeLoader)
++
++
++if __name__ == "__main__":
++    pytest.main([__file__, "-v"])
+-- 
+2.51.1
+

--- a/salt/backport-add-maintain-m-privilege-to-postgres-module.patch
+++ b/salt/backport-add-maintain-m-privilege-to-postgres-module.patch
@@ -1,0 +1,5014 @@
+From f859336115190e3b41569fa3c52cd6f804b3afad Mon Sep 17 00:00:00 2001
+From: Alexander Graul <agraul@suse.com>
+Date: Fri, 16 Jan 2026 11:07:48 +0100
+Subject: [PATCH] Backport "Add MAINTAIN (m) privilege to postgres
+ module lookup tables"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+* Initial port of test/unit/module/test_postgres.py to pytests
+
+(cherry picked from commit a919a3ea8782b252a3e65ad8787f73a906cf7fa5)
+
+* Added tablespace_create test
+
+(cherry picked from commit 452f6bdf855ae4484145f48d3a433dc949e2a775)
+
+* Updated test per reviewer suggestion
+
+(cherry picked from commit d2481582f4879ab0ddc52a9c0415b3e5dbf55326)
+
+* Further update to test per reviewer comment
+
+(cherry picked from commit 4dbd8caec2bfd2bbaf4526320ad9583b8e17e6bc)
+
+* Migrated test_deb_postgre.py to pytests
+
+(cherry picked from commit 0963209cc3e20ba6dfa3abdd5d716f400dafa910)
+
+* Updates tests for tablespace_list, tablespace_exists and tablespace_remove
+
+(cherry picked from commit 7714b22f075b81150deb87cd7c2bed9b49f55d74)
+
+* Updated tests with tablespace alter tests
+
+(cherry picked from commit 3c4aa715ba8bb8f8533e3e1ff081e57db746d1f4)
+
+* Updated asserts and limit testing to Linux only
+
+(cherry picked from commit e919e8f63e0b2e72a531cfce0b3bbc052f14ca69)
+
+* Converted global constants to pytest fixtures per reviewer comments
+
+(cherry picked from commit c6e8fa3b1781c997bc9e1c83e28d3950c7507ad5)
+
+* add 'm = MAINTAIN' privilege to the maps in the postgres module
+
+(cherry picked from commit a6b8fe4e8ebe8a15a68852eeda64a045f6ff5e46)
+
+* add changelog entry for bugfix to #66962
+
+(cherry picked from commit d422032f21fde7cec8c4ac3f9d628dc24c1cc3da)
+
+* add reference to MAINTAIN to the docs
+
+(cherry picked from commit 0a77c112a15e5d98ef50e6492e2cac9adbde0449)
+
+* add MAINTAIN privilege to PostgreSQL tests
+
+(cherry picked from commit cb26d8d0eef62e08a7581f2a03b1a4bb17176c04)
+
+---------
+
+Co-authored-by: David Murphy < dmurphy@saltstack.com>
+Co-authored-by: Jonas Maurus <jonas-github@maurus.net>
+---
+ changelog/66962.fixed.md                      |    1 +
+ salt/modules/postgres.py                      |    3 +-
+ salt/states/postgres_privileges.py            |    2 +
+ .../pytests/unit/modules/test_deb_postgres.py |  165 ++
+ tests/pytests/unit/modules/test_postgres.py   | 2398 ++++++++++++++++-
+ tests/unit/modules/test_deb_postgres.py       |  184 --
+ tests/unit/modules/test_postgres.py           | 2086 --------------
+ 7 files changed, 2562 insertions(+), 2277 deletions(-)
+ create mode 100644 changelog/66962.fixed.md
+ create mode 100644 tests/pytests/unit/modules/test_deb_postgres.py
+ delete mode 100644 tests/unit/modules/test_deb_postgres.py
+ delete mode 100644 tests/unit/modules/test_postgres.py
+
+diff --git a/changelog/66962.fixed.md b/changelog/66962.fixed.md
+new file mode 100644
+index 0000000000..a1ebb56f41
+--- /dev/null
++++ b/changelog/66962.fixed.md
+@@ -0,0 +1 @@
++Added support for MAINTAIN (m) privilege to salt.modules.postgres
+diff --git a/salt/modules/postgres.py b/salt/modules/postgres.py
+index f73959a92e..a2b6b8adc1 100644
+--- a/salt/modules/postgres.py
++++ b/salt/modules/postgres.py
+@@ -100,6 +100,7 @@ _PRIVILEGES_MAP = {
+     "X": "EXECUTE",
+     "x": "REFERENCES",
+     "d": "DELETE",
++    "m": "MAINTAIN",
+     "*": "GRANT",
+ }
+ _PRIVILEGES_OBJECTS = frozenset(
+@@ -115,7 +116,7 @@ _PRIVILEGES_OBJECTS = frozenset(
+     )
+ )
+ _PRIVILEGE_TYPE_MAP = {
+-    "table": "arwdDxt",
++    "table": "arwdDxtm",
+     "tablespace": "C",
+     "language": "U",
+     "sequence": "rwU",
+diff --git a/salt/states/postgres_privileges.py b/salt/states/postgres_privileges.py
+index 9241c2de6e..e6542077db 100644
+--- a/salt/states/postgres_privileges.py
++++ b/salt/states/postgres_privileges.py
+@@ -130,6 +130,7 @@ def present(
+        - EXECUTE
+        - REFERENCES
+        - DELETE
++       - MAINTAIN
+        - ALL
+ 
+        :note: privileges should not be set when granting group membership
+@@ -260,6 +261,7 @@ def absent(
+        - EXECUTE
+        - REFERENCES
+        - DELETE
++       - MAINTAIN
+        - ALL
+ 
+        :note: privileges should not be set when revoking group membership
+diff --git a/tests/pytests/unit/modules/test_deb_postgres.py b/tests/pytests/unit/modules/test_deb_postgres.py
+new file mode 100644
+index 0000000000..f125f96707
+--- /dev/null
++++ b/tests/pytests/unit/modules/test_deb_postgres.py
+@@ -0,0 +1,165 @@
++import logging
++
++import pytest
++
++import salt.modules.deb_postgres as deb_postgres
++from tests.support.mock import Mock, patch
++
++log = logging.getLogger(__name__)
++
++pytestmark = [
++    pytest.mark.skip_unless_on_linux(reason="Only supported on Linux family"),
++]
++
++
++@pytest.fixture
++def get_lscuster():
++    return """\
++8.4 main 5432 online postgres /srv/8.4/main \
++        /var/log/postgresql/postgresql-8.4-main.log
++9.1 main 5433 online postgres /srv/9.1/main \
++        /var/log/postgresql/postgresql-9.1-main.log
++"""
++
++
++@pytest.fixture
++def configure_loader_modules(get_lscuster):
++    return {
++        deb_postgres: {
++            "__salt__": {
++                "config.option": Mock(),
++                "cmd.run_all": Mock(return_value={"stdout": get_lscuster}),
++                "file.chown": Mock(),
++                "file.remove": Mock(),
++            }
++        }
++    }
++
++
++def test_cluster_create():
++    with patch("salt.utils.path.which", Mock(return_value="/usr/bin/pg_createcluster")):
++        expected_cmdstr = (
++            "/usr/bin/pg_createcluster "
++            "--port 5432 --locale fr_FR --encoding UTF-8 "
++            "--datadir /opt/postgresql "
++            "9.3 main"
++        )
++
++        deb_postgres.cluster_create(
++            "9.3",
++            "main",
++            port="5432",
++            locale="fr_FR",
++            encoding="UTF-8",
++            datadir="/opt/postgresql",
++        )
++        assert deb_postgres.__salt__["cmd.run_all"].call_args[0][0] == expected_cmdstr
++
++
++def test_cluster_create_with_initdb_options():
++    with patch("salt.utils.path.which", Mock(return_value="/usr/bin/pg_createcluster")):
++        expected_cmdstr = (
++            "/usr/bin/pg_createcluster "
++            "--port 5432 --locale fr_FR --encoding UTF-8 "
++            "--datadir /opt/postgresql "
++            "11 main "
++            "-- "
++            "--allow-group-access "
++            "--data-checksums "
++            "--wal-segsize 32"
++        )
++
++        deb_postgres.cluster_create(
++            "11",
++            "main",
++            port="5432",
++            locale="fr_FR",
++            encoding="UTF-8",
++            datadir="/opt/postgresql",
++            allow_group_access=True,
++            data_checksums=True,
++            wal_segsize="32",
++        )
++        assert deb_postgres.__salt__["cmd.run_all"].call_args[0][0] == expected_cmdstr
++
++
++def test_cluster_create_with_float():
++    with patch("salt.utils.path.which", Mock(return_value="/usr/bin/pg_createcluster")):
++        expected_cmdstr = (
++            "/usr/bin/pg_createcluster "
++            "--port 5432 --locale fr_FR --encoding UTF-8 "
++            "--datadir /opt/postgresql "
++            "9.3 main"
++        )
++
++        deb_postgres.cluster_create(
++            9.3,
++            "main",
++            port="5432",
++            locale="fr_FR",
++            encoding="UTF-8",
++            datadir="/opt/postgresql",
++        )
++        assert deb_postgres.__salt__["cmd.run_all"].call_args[0][0] == expected_cmdstr
++
++
++def test_parse_pg_lsclusters(get_lscuster):
++    with patch("salt.utils.path.which", Mock(return_value="/usr/bin/pg_lsclusters")):
++        stdout = get_lscuster
++        maxDiff = None
++        expected = {
++            "8.4/main": {
++                "port": 5432,
++                "status": "online",
++                "user": "postgres",
++                "datadir": "/srv/8.4/main",
++                "log": "/var/log/postgresql/postgresql-8.4-main.log",
++            },
++            "9.1/main": {
++                "port": 5433,
++                "status": "online",
++                "user": "postgres",
++                "datadir": "/srv/9.1/main",
++                "log": "/var/log/postgresql/postgresql-9.1-main.log",
++            },
++        }
++        assert deb_postgres._parse_pg_lscluster(stdout) == expected
++
++
++def test_cluster_list():
++    with patch("salt.utils.path.which", Mock(return_value="/usr/bin/pg_lsclusters")):
++        return_list = deb_postgres.cluster_list()
++        assert (
++            deb_postgres.__salt__["cmd.run_all"].call_args[0][0]
++            == "/usr/bin/pg_lsclusters --no-header"
++        )
++
++        return_dict = deb_postgres.cluster_list(verbose=True)
++        assert isinstance(return_dict, dict)
++
++
++def test_cluster_exists():
++    assert deb_postgres.cluster_exists("8.4")
++    assert deb_postgres.cluster_exists("8.4", "main")
++    assert not deb_postgres.cluster_exists("3.4", "main")
++
++
++def test_cluster_delete():
++    with patch("salt.utils.path.which", Mock(return_value="/usr/bin/pg_dropcluster")):
++        deb_postgres.cluster_remove("9.3", "main")
++        assert (
++            deb_postgres.__salt__["cmd.run_all"].call_args[0][0]
++            == "/usr/bin/pg_dropcluster 9.3 main"
++        )
++
++        deb_postgres.cluster_remove("9.3", "main", stop=True)
++        assert (
++            deb_postgres.__salt__["cmd.run_all"].call_args[0][0]
++            == "/usr/bin/pg_dropcluster --stop 9.3 main"
++        )
++
++        deb_postgres.cluster_remove(9.3, "main", stop=True)
++        assert (
++            deb_postgres.__salt__["cmd.run_all"].call_args[0][0]
++            == "/usr/bin/pg_dropcluster --stop 9.3 main"
++        )
+diff --git a/tests/pytests/unit/modules/test_postgres.py b/tests/pytests/unit/modules/test_postgres.py
+index 393c087d16..be9e05fc96 100644
+--- a/tests/pytests/unit/modules/test_postgres.py
++++ b/tests/pytests/unit/modules/test_postgres.py
+@@ -1,8 +1,17 @@
++import datetime
++import re
++
+ import pytest
+ 
+ import salt.modules.config as configmod
+ import salt.modules.postgres as postgres
+-from tests.support.mock import MagicMock, patch
++from salt.exceptions import SaltInvocationError
++from tests.support.mock import MagicMock, Mock, call, patch
++
++pytestmark = [
++    pytest.mark.skip_unless_on_linux(reason="Only supported on Linux family"),
++]
++
+ 
+ # 'md5' + md5('password' + 'username')
+ md5_pw = "md55a231fcdb710d73268c4f44283487ba2"
+@@ -13,9 +22,47 @@ scram_pw = (
+     "LzAh/MGUdjYkdbDzcOKpfGwa3WwPUsyGcY+TEnSpcto="
+ )
+ 
+-test_privileges_list_function_csv = (
+-    'name\n"{baruwatest=X/baruwatest,bayestest=r/baruwatest,baruwa=X*/baruwatest}"\n'
+-)
++
++@pytest.fixture
++def get_test_privileges_list_function_csv():
++    return """name
++"{baruwatest=X/baruwatest,bayestest=r/baruwatest,baruwa=X*/baruwatest}"
++"""
++
++
++@pytest.fixture
++def get_test_list_db_csv():
++    return """Name,Owner,Encoding,Collate,Ctype,Access privileges,Tablespace
++template1,postgres,LATIN1,en_US,en_US,"{=c/postgres,postgres=CTc/postgres}",pg_default
++template0,postgres,LATIN1,en_US,en_US,"{=c/postgres,postgres=CTc/postgres}",pg_default
++postgres,postgres,LATIN1,en_US,en_US,,pg_default
++test_db,postgres,LATIN1,en_US,en_US,,pg_default
++"""
++
++
++@pytest.fixture
++def get_test_list_schema_csv():
++    return """name,owner,acl
++public,postgres,"{postgres=UC/postgres,=UC/postgres}"
++pg_toast,postgres,""
++"""
++
++
++@pytest.fixture
++def get_test_list_language_csv():
++    return "Name\ninternal\nc\nsql\nplpgsql\n"
++
++
++@pytest.fixture
++def get_test_privileges_list_table_csv():
++    return """name
++"{baruwatest=arwdDxtm/baruwatest,bayestest=arwd/baruwatest,baruwa=a*r*w*d*D*x*t*m*/baruwatest}"
++"""
++
++
++@pytest.fixture
++def get_test_privileges_list_group_csv():
++    return "rolname,admin_option\nbaruwa,f\nbaruwatest2,t\nbaruwatest,f\n"
+ 
+ 
+ @pytest.fixture
+@@ -73,11 +120,11 @@ def test_verify_password(role, password, verifier, method, result):
+     assert postgres._verify_password(role, password, verifier, method) == result
+ 
+ 
+-def test_has_privileges_with_function():
++def test_has_privileges_with_function(get_test_privileges_list_function_csv):
+     with patch(
+         "salt.modules.postgres._run_psql",
+         MagicMock(
+-            return_value={"retcode": 0, "stdout": test_privileges_list_function_csv}
++            return_value={"retcode": 0, "stdout": get_test_privileges_list_function_csv}
+         ),
+     ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
+         ret = postgres.has_privileges(
+@@ -181,3 +228,2342 @@ def test__run_initdb_with_timeout():
+             with patch.dict(configmod.__opts__, {"postgres.pass": None}):
+                 postgres._run_initdb("fakename", runas="saltuser")
+                 cmd_run_mock.assert_called_with(cmd_str, timeout=0, **kwargs)
++
++
++def test_run_psql():
++    postgres._run_psql('echo "hi"')
++    cmd = postgres.__salt__["cmd.run_all"]
++    assert cmd.call_args[1]["runas"] == "postgres"
++
++
++def test_db_alter():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        ret = postgres.db_alter(
++            "dbname",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            tablespace="testspace",
++            owner="otheruser",
++            runas="foo",
++        )
++        assert ret is True
++
++        postgres._run_psql.assert_has_calls(
++            [
++                call(
++                    [
++                        "/usr/bin/pgsql",
++                        "--no-align",
++                        "--no-readline",
++                        "--no-psqlrc",
++                        "--no-password",
++                        "--username",
++                        "testuser",
++                        "--host",
++                        "testhost",
++                        "--port",
++                        "testport",
++                        "--dbname",
++                        "maint_db",
++                        "-c",
++                        'ALTER DATABASE "dbname" OWNER TO "otheruser"',
++                    ],
++                    host="testhost",
++                    user="testuser",
++                    password="foo",
++                    runas="foo",
++                    port="testport",
++                ),
++                call(
++                    [
++                        "/usr/bin/pgsql",
++                        "--no-align",
++                        "--no-readline",
++                        "--no-psqlrc",
++                        "--no-password",
++                        "--username",
++                        "testuser",
++                        "--host",
++                        "testhost",
++                        "--port",
++                        "testport",
++                        "--dbname",
++                        "maint_db",
++                        "-c",
++                        'ALTER DATABASE "dbname" SET TABLESPACE "testspace"',
++                    ],
++                    host="testhost",
++                    user="testuser",
++                    password="foo",
++                    runas="foo",
++                    port="testport",
++                ),
++            ]
++        )
++
++
++def test_db_alter_owner_recurse():
++    with patch(
++        "salt.modules.postgres.owner_to", Mock(return_value={"retcode": None})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        postgres.db_alter(
++            "dbname",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            tablespace="testspace",
++            owner="otheruser",
++            owner_recurse=True,
++            runas="foo",
++        )
++        postgres.owner_to.assert_called_once_with(
++            "dbname",
++            "otheruser",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            password="foo",
++            runas="foo",
++        )
++
++
++def test_db_create():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        postgres.db_create(
++            "dbname",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            tablespace="testspace",
++            owner="otheruser",
++            runas="foo",
++        )
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "maint_db",
++                "-c",
++                'CREATE DATABASE "dbname" WITH TABLESPACE = "testspace" '
++                'OWNER = "otheruser"',
++            ],
++            host="testhost",
++            user="testuser",
++            password="foo",
++            runas="foo",
++            port="testport",
++        )
++
++
++def test_db_create_empty_string_param():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        postgres.db_create(
++            "dbname",
++            lc_collate="",
++            encoding="utf8",
++            user="testuser",
++            host="testhost",
++            port=1234,
++            maintenance_db="maint_db",
++            password="foo",
++        )
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "1234",
++                "--dbname",
++                "maint_db",
++                "-c",
++                "CREATE DATABASE \"dbname\" WITH ENCODING = 'utf8' LC_COLLATE = ''",
++            ],
++            host="testhost",
++            password="foo",
++            port=1234,
++            runas=None,
++            user="testuser",
++        )
++
++
++def test_db_create_with_trivial_sql_injection():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        pytest.raises(
++            SaltInvocationError,
++            postgres.db_create,
++            "dbname",
++            lc_collate="foo' ENCODING='utf8",
++        )
++
++
++def test_db_exists(get_test_list_db_csv):
++    with patch(
++        "salt.modules.postgres._run_psql",
++        Mock(return_value={"retcode": 0, "stdout": get_test_list_db_csv}),
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        ret = postgres.db_exists(
++            "test_db",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            runas="foo",
++        )
++        assert ret is True
++
++
++def test_db_list(get_test_list_db_csv):
++    with patch(
++        "salt.modules.postgres._run_psql",
++        Mock(return_value={"retcode": 0, "stdout": get_test_list_db_csv}),
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        ret = postgres.db_list(
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            runas="foo",
++        )
++        assert ret == {
++            "test_db": {
++                "Encoding": "LATIN1",
++                "Ctype": "en_US",
++                "Tablespace": "pg_default",
++                "Collate": "en_US",
++                "Owner": "postgres",
++                "Access privileges": "",
++            },
++            "template1": {
++                "Encoding": "LATIN1",
++                "Ctype": "en_US",
++                "Tablespace": "pg_default",
++                "Collate": "en_US",
++                "Owner": "postgres",
++                "Access privileges": "{=c/postgres,postgres=CTc/postgres}",
++            },
++            "template0": {
++                "Encoding": "LATIN1",
++                "Ctype": "en_US",
++                "Tablespace": "pg_default",
++                "Collate": "en_US",
++                "Owner": "postgres",
++                "Access privileges": "{=c/postgres,postgres=CTc/postgres}",
++            },
++            "postgres": {
++                "Encoding": "LATIN1",
++                "Ctype": "en_US",
++                "Tablespace": "pg_default",
++                "Collate": "en_US",
++                "Owner": "postgres",
++                "Access privileges": "",
++            },
++        }
++
++
++def test_db_remove():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        postgres.db_remove(
++            "test_db",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            runas="foo",
++        )
++
++        calls = (
++            call(
++                [
++                    "/usr/bin/pgsql",
++                    "--no-align",
++                    "--no-readline",
++                    "--no-psqlrc",
++                    "--no-password",
++                    "--username",
++                    "testuser",
++                    "--host",
++                    "testhost",
++                    "--port",
++                    "testport",
++                    "--dbname",
++                    "maint_db",
++                    "-c",
++                    'REVOKE CONNECT ON DATABASE "test_db" FROM public;',
++                ],
++                host="testhost",
++                password="foo",
++                port="testport",
++                runas="foo",
++                user="testuser",
++            ),
++            call(
++                [
++                    "/usr/bin/pgsql",
++                    "--no-align",
++                    "--no-readline",
++                    "--no-psqlrc",
++                    "--no-password",
++                    "--username",
++                    "testuser",
++                    "--host",
++                    "testhost",
++                    "--port",
++                    "testport",
++                    "--dbname",
++                    "maint_db",
++                    "-c",
++                    "SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity"
++                    " WHERE datname = 'test_db' AND pid <> pg_backend_pid();",
++                ],
++                host="testhost",
++                password="foo",
++                port="testport",
++                runas="foo",
++                user="testuser",
++            ),
++            call(
++                [
++                    "/usr/bin/pgsql",
++                    "--no-align",
++                    "--no-readline",
++                    "--no-psqlrc",
++                    "--no-password",
++                    "--username",
++                    "testuser",
++                    "--host",
++                    "testhost",
++                    "--port",
++                    "testport",
++                    "--dbname",
++                    "maint_db",
++                    "-c",
++                    'DROP DATABASE "test_db";',
++                ],
++                host="testhost",
++                password="foo",
++                port="testport",
++                runas="foo",
++                user="testuser",
++            ),
++        )
++
++        postgres._run_psql.assert_has_calls(calls, any_order=True)
++
++
++def test_group_create():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
++        "salt.modules.postgres.user_exists", Mock(return_value=False)
++    ):
++        postgres.group_create(
++            "testgroup",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            createdb=False,
++            encrypted=False,
++            superuser=False,
++            replication=False,
++            rolepassword="testrolepass",
++            groups="testgroup",
++            runas="foo",
++        )
++        # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
++        # The first 14 elements of this list are initial args used in all (or
++        # virtually all) commands run through _run_psql(), so the actual SQL
++        # query will be in the 15th argument.
++        assert postgres._run_psql.call_args[0][0][14].startswith("CREATE ROLE")
++
++
++def test_group_remove():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
++        "salt.modules.postgres.user_exists", Mock(return_value=True)
++    ):
++        postgres.group_remove(
++            "testgroup",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            runas="foo",
++        )
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "maint_db",
++                "-c",
++                'DROP ROLE "testgroup"',
++            ],
++            host="testhost",
++            user="testuser",
++            password="foo",
++            runas="foo",
++            port="testport",
++        )
++
++
++def test_group_update():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch(
++        "salt.modules.postgres.role_get",
++        Mock(return_value={"superuser": False}),
++    ):
++        postgres.group_update(
++            "testgroup",
++            user='"testuser"',
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            createdb=False,
++            encrypted=False,
++            replication=False,
++            rolepassword="test_role_pass",
++            groups="testgroup",
++            runas="foo",
++        )
++        # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
++        # The first 14 elements of this list are initial args used in all (or
++        # virtually all) commands run through _run_psql(), so the actual SQL
++        # query will be in the 15th argument.
++        assert re.match(
++            'ALTER.* "testgroup" .* UNENCRYPTED PASSWORD',
++            postgres._run_psql.call_args[0][0][14],
++        )
++
++
++def test_user_create():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.modules.postgres.user_exists", Mock(return_value=False)):
++        postgres.user_create(
++            "testuser",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_test",
++            password="test_pass",
++            login=True,
++            createdb=False,
++            createroles=False,
++            encrypted=False,
++            superuser=False,
++            replication=False,
++            rolepassword="test_role_pass",
++            valid_until="2042-07-01",
++            groups="test_groups",
++            runas="foo",
++        )
++        # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
++        # The first 14 elements of this list are initial args used in all (or
++        # virtually all) commands run through _run_psql(), so the actual SQL
++        # query will be in the 15th argument.
++        call = postgres._run_psql.call_args[0][0][14]
++        assert re.match('CREATE ROLE "testuser"', call)
++        for i in (
++            "INHERIT",
++            "NOCREATEDB",
++            "NOCREATEROLE",
++            "NOSUPERUSER",
++            "NOREPLICATION",
++            "LOGIN",
++            "UNENCRYPTED",
++            "PASSWORD",
++            "VALID UNTIL",
++        ):
++            assert i in call, f"{i} not in {call}"
++
++
++def test_user_exists():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.modules.postgres.version", Mock(return_value="9.1")), patch(
++        "salt.modules.postgres.psql_query",
++        Mock(
++            return_value=[
++                {
++                    "name": "test_user",
++                    "superuser": "t",
++                    "inherits privileges": "t",
++                    "can create roles": "t",
++                    "can create databases": "t",
++                    "can update system catalogs": "t",
++                    "can login": "t",
++                    "replication": None,
++                    "password": "test_password",
++                    "connections": "-1",
++                    "groups": "",
++                    "expiry time": "",
++                    "defaults variables": None,
++                }
++            ]
++        ),
++    ):
++        ret = postgres.user_exists(
++            "test_user",
++            user="test_user",
++            host="test_host",
++            port="test_port",
++            maintenance_db="maint_db",
++            password="test_password",
++            runas="foo",
++        )
++        assert ret is True
++
++
++def test_user_list():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.modules.postgres.version", Mock(return_value="9.1")), patch(
++        "salt.modules.postgres.psql_query",
++        Mock(
++            return_value=[
++                {
++                    "name": "test_user",
++                    "superuser": "t",
++                    "inherits privileges": "t",
++                    "can create roles": "t",
++                    "can create databases": "t",
++                    "can update system catalogs": "t",
++                    "can login": "t",
++                    "replication": None,
++                    "connections": "-1",
++                    "groups": "",
++                    "expiry time": "2017-08-16 08:57:46",
++                    "defaults variables": None,
++                }
++            ]
++        ),
++    ):
++        ret = postgres.user_list(
++            "test_user",
++            host="test_host",
++            port="test_port",
++            maintenance_db="maint_db",
++            password="test_password",
++            runas="foo",
++        )
++
++        assert ret == {
++            "test_user": {
++                "superuser": True,
++                "defaults variables": None,
++                "can create databases": True,
++                "can create roles": True,
++                "connections": None,
++                "replication": None,
++                "expiry time": datetime.datetime(2017, 8, 16, 8, 57, 46),
++                "can login": True,
++                "can update system catalogs": True,
++                "groups": [],
++                "inherits privileges": True,
++            }
++        }
++
++
++def test_user_remove():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
++        "salt.modules.postgres.version", Mock(return_value="9.1")
++    ), patch(
++        "salt.modules.postgres.user_exists", Mock(return_value=True)
++    ):
++        postgres.user_remove(
++            "testuser",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="testpassword",
++            runas="foo",
++        )
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "maint_db",
++                "-c",
++                'DROP ROLE "testuser"',
++            ],
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++            runas="foo",
++        )
++
++
++def test_user_update():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch(
++        "salt.modules.postgres.role_get",
++        Mock(return_value={"superuser": False}),
++    ):
++        postgres.user_update(
++            "test_username",
++            user="test_user",
++            host="test_host",
++            port="test_port",
++            maintenance_db="test_maint",
++            password="test_pass",
++            createdb=False,
++            createroles=False,
++            encrypted=False,
++            inherit=True,
++            login=True,
++            replication=False,
++            rolepassword="test_role_pass",
++            valid_until="2017-07-01",
++            groups="test_groups",
++            runas="foo",
++        )
++        # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
++        # The first 14 elements of this list are initial args used in all (or
++        # virtually all) commands run through _run_psql(), so the actual SQL
++        # query will be in the 15th argument.
++        assert re.match(
++            'ALTER ROLE "test_username" WITH  INHERIT NOCREATEDB '
++            "NOCREATEROLE NOREPLICATION LOGIN "
++            "UNENCRYPTED PASSWORD ['\"]{0,5}test_role_pass['\"]{0,5} "
++            "VALID UNTIL '2017-07-01';"
++            ' GRANT "test_groups" TO "test_username"',
++            postgres._run_psql.call_args[0][0][14],
++        )
++
++
++def test_user_update2():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch(
++        "salt.modules.postgres.role_get",
++        Mock(return_value={"superuser": False}),
++    ):
++        postgres.user_update(
++            "test_username",
++            user="test_user",
++            host="test_host",
++            port="test_port",
++            maintenance_db="test_maint",
++            password="test_pass",
++            createdb=False,
++            createroles=True,
++            encrypted=False,
++            inherit=True,
++            login=True,
++            replication=False,
++            groups="test_groups",
++            runas="foo",
++        )
++        # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
++        # The first 14 elements of this list are initial args used in all (or
++        # virtually all) commands run through _run_psql(), so the actual SQL
++        # query will be in the 15th argument.
++        assert re.match(
++            'ALTER ROLE "test_username" WITH  INHERIT NOCREATEDB '
++            "CREATEROLE NOREPLICATION LOGIN;"
++            ' GRANT "test_groups" TO "test_username"',
++            postgres._run_psql.call_args[0][0][14],
++        )
++
++
++def test_user_update3():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch(
++        "salt.modules.postgres.role_get",
++        Mock(return_value={"superuser": False}),
++    ):
++        postgres.user_update(
++            "test_username",
++            user="test_user",
++            host="test_host",
++            port="test_port",
++            maintenance_db="test_maint",
++            password="test_pass",
++            createdb=False,
++            createroles=True,
++            encrypted=False,
++            inherit=True,
++            login=True,
++            rolepassword=False,
++            replication=False,
++            groups="test_groups",
++            runas="foo",
++        )
++        # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
++        # The first 14 elements of this list are initial args used in all (or
++        # virtually all) commands run through _run_psql(), so the actual SQL
++        # query will be in the 15th argument.
++        assert re.match(
++            'ALTER ROLE "test_username" WITH  INHERIT NOCREATEDB '
++            "CREATEROLE NOREPLICATION LOGIN NOPASSWORD;"
++            ' GRANT "test_groups" TO "test_username"',
++            postgres._run_psql.call_args[0][0][14],
++        )
++
++
++def test_user_update_encrypted_passwd():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch(
++        "salt.modules.postgres.role_get",
++        Mock(return_value={"superuser": False}),
++    ):
++        postgres.user_update(
++            "test_username",
++            user="test_user",
++            host="test_host",
++            port="test_port",
++            maintenance_db="test_maint",
++            password="test_pass",
++            createdb=False,
++            createroles=True,
++            encrypted=True,
++            inherit=True,
++            login=True,
++            rolepassword="foobar",
++            replication=False,
++            groups="test_groups",
++            runas="foo",
++        )
++        # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
++        # The first 14 elements of this list are initial args used in all (or
++        # virtually all) commands run through _run_psql(), so the actual SQL
++        # query will be in the 15th argument.
++        assert re.match(
++            'ALTER ROLE "test_username" WITH  INHERIT NOCREATEDB '
++            "CREATEROLE NOREPLICATION LOGIN "
++            "ENCRYPTED PASSWORD "
++            "['\"]{0,5}md531c27e68d3771c392b52102c01be1da1['\"]{0,5}"
++            '; GRANT "test_groups" TO "test_username"',
++            postgres._run_psql.call_args[0][0][14],
++        )
++
++
++def test_version():
++    with patch(
++        "salt.modules.postgres._run_psql",
++        Mock(return_value={"retcode": 0, "stdout": "9.1.9"}),
++    ):
++        postgres.version(
++            user="test_user",
++            host="test_host",
++            port="test_port",
++            maintenance_db="test_maint",
++            password="test_pass",
++            runas="foo",
++        )
++        # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
++        # The first 14 elements of this list are initial args used in all (or
++        # virtually all) commands run through _run_psql(), so the actual SQL
++        # query will be in the 15th argument.
++        assert re.match(
++            "SELECT setting FROM pg_catalog.pg_settings",
++            postgres._run_psql.call_args[0][0][14],
++        )
++
++
++def test_installed_extensions():
++    with patch(
++        "salt.modules.postgres.psql_query",
++        Mock(return_value=[{"extname": "foo", "extversion": "1"}]),
++    ):
++        exts = postgres.installed_extensions()
++        assert exts == {"foo": {"extversion": "1", "extname": "foo"}}
++
++
++def test_available_extensions():
++    with patch(
++        "salt.modules.postgres.psql_query",
++        Mock(return_value=[{"name": "foo", "default_version": "1"}]),
++    ):
++        exts = postgres.available_extensions()
++        assert exts == {"foo": {"default_version": "1", "name": "foo"}}
++
++
++def test_drop_extension2():
++    with patch(
++        "salt.modules.postgres.installed_extensions", Mock(side_effect=[{}, {}])
++    ):
++        with patch(
++            "salt.modules.postgres._psql_prepare_and_run", Mock(return_value=None)
++        ):
++            with patch(
++                "salt.modules.postgres.available_extensions",
++                Mock(return_value={"foo": {"default_version": "1", "name": "foo"}}),
++            ):
++                assert postgres.drop_extension("foo")
++
++
++def test_drop_extension3():
++    with patch(
++        "salt.modules.postgres.installed_extensions",
++        Mock(side_effect=[{"foo": {"extversion": "1", "extname": "foo"}}, {}]),
++    ):
++        with patch(
++            "salt.modules.postgres._psql_prepare_and_run", Mock(return_value=None)
++        ):
++            with patch(
++                "salt.modules.postgres.available_extensions",
++                Mock(return_value={"foo": {"default_version": "1", "name": "foo"}}),
++            ):
++                assert postgres.drop_extension("foo")
++
++
++def test_drop_extension1():
++    with patch(
++        "salt.modules.postgres.installed_extensions",
++        Mock(
++            side_effect=[
++                {"foo": {"extversion": "1", "extname": "foo"}},
++                {"foo": {"extversion": "1", "extname": "foo"}},
++            ]
++        ),
++    ):
++        with patch(
++            "salt.modules.postgres._psql_prepare_and_run", Mock(return_value=None)
++        ):
++            with patch(
++                "salt.modules.postgres.available_extensions",
++                Mock(return_value={"foo": {"default_version": "1", "name": "foo"}}),
++            ):
++                assert not postgres.drop_extension("foo")
++
++
++def test_create_mtdata():
++    with patch(
++        "salt.modules.postgres.installed_extensions",
++        Mock(
++            return_value={
++                "foo": {
++                    "extversion": "0.8",
++                    "extrelocatable": "t",
++                    "schema_name": "foo",
++                    "extname": "foo",
++                }
++            },
++        ),
++    ):
++        with patch(
++            "salt.modules.postgres.available_extensions",
++            Mock(return_value={"foo": {"default_version": "1.4", "name": "foo"}}),
++        ):
++            ret = postgres.create_metadata("foo", schema="bar", ext_version="1.4")
++            assert postgres._EXTENSION_INSTALLED in ret
++            assert postgres._EXTENSION_TO_UPGRADE in ret
++            assert postgres._EXTENSION_TO_MOVE in ret
++
++            ret = postgres.create_metadata("foo", schema="foo", ext_version="0.4")
++            assert postgres._EXTENSION_INSTALLED in ret
++            assert postgres._EXTENSION_TO_UPGRADE not in ret
++            assert postgres._EXTENSION_TO_MOVE not in ret
++
++            ret = postgres.create_metadata("foo")
++            assert postgres._EXTENSION_INSTALLED in ret
++            assert postgres._EXTENSION_TO_UPGRADE not in ret
++            assert postgres._EXTENSION_TO_MOVE not in ret
++
++            ret = postgres.create_metadata("foobar")
++            assert postgres._EXTENSION_NOT_INSTALLED in ret
++            assert postgres._EXTENSION_INSTALLED not in ret
++            assert postgres._EXTENSION_TO_UPGRADE not in ret
++            assert postgres._EXTENSION_TO_MOVE not in ret
++
++
++def test_create_extension_newerthan():
++    """
++    scenario of creating upgrading extensions with possible schema and
++    version specifications
++    """
++    with patch(
++        "salt.modules.postgres.create_metadata",
++        Mock(
++            side_effect=[
++                # create succeeded
++                [postgres._EXTENSION_NOT_INSTALLED],
++                [postgres._EXTENSION_INSTALLED],
++                [postgres._EXTENSION_NOT_INSTALLED],
++                [postgres._EXTENSION_INSTALLED],
++                # create failed
++                [postgres._EXTENSION_NOT_INSTALLED],
++                [postgres._EXTENSION_NOT_INSTALLED],
++                # move+upgrade succeeded
++                [
++                    postgres._EXTENSION_TO_MOVE,
++                    postgres._EXTENSION_TO_UPGRADE,
++                    postgres._EXTENSION_INSTALLED,
++                ],
++                [postgres._EXTENSION_INSTALLED],
++                # move succeeded
++                [postgres._EXTENSION_TO_MOVE, postgres._EXTENSION_INSTALLED],
++                [postgres._EXTENSION_INSTALLED],
++                # upgrade succeeded
++                [postgres._EXTENSION_TO_UPGRADE, postgres._EXTENSION_INSTALLED],
++                [postgres._EXTENSION_INSTALLED],
++                # upgrade failed
++                [postgres._EXTENSION_TO_UPGRADE, postgres._EXTENSION_INSTALLED],
++                [postgres._EXTENSION_TO_UPGRADE, postgres._EXTENSION_INSTALLED],
++                # move failed
++                [postgres._EXTENSION_TO_MOVE, postgres._EXTENSION_INSTALLED],
++                [postgres._EXTENSION_TO_MOVE, postgres._EXTENSION_INSTALLED],
++            ]
++        ),
++    ):
++        with patch(
++            "salt.modules.postgres._psql_prepare_and_run", Mock(return_value=None)
++        ):
++            with patch(
++                "salt.modules.postgres.available_extensions",
++                Mock(return_value={"foo": {"default_version": "1.4", "name": "foo"}}),
++            ):
++                assert postgres.create_extension("foo")
++                assert re.match(
++                    'CREATE EXTENSION IF NOT EXISTS "foo" ;',
++                    postgres._psql_prepare_and_run.call_args[0][0][1],
++                )
++
++                assert postgres.create_extension(
++                    "foo", schema="a", ext_version="b", from_version="c"
++                )
++                assert re.match(
++                    'CREATE EXTENSION IF NOT EXISTS "foo" '
++                    'WITH SCHEMA "a" VERSION b FROM c ;',
++                    postgres._psql_prepare_and_run.call_args[0][0][1],
++                )
++                assert not postgres.create_extension("foo")
++
++                ret = postgres.create_extension("foo", ext_version="a", schema="b")
++                assert ret is True
++                assert re.match(
++                    'ALTER EXTENSION "foo" SET SCHEMA "b";'
++                    ' ALTER EXTENSION "foo" UPDATE TO a;',
++                    postgres._psql_prepare_and_run.call_args[0][0][1],
++                )
++
++                ret = postgres.create_extension("foo", ext_version="a", schema="b")
++                assert ret is True
++                assert re.match(
++                    'ALTER EXTENSION "foo" SET SCHEMA "b";',
++                    postgres._psql_prepare_and_run.call_args[0][0][1],
++                )
++
++                ret = postgres.create_extension("foo", ext_version="a", schema="b")
++                assert ret is True
++                assert re.match(
++                    'ALTER EXTENSION "foo" UPDATE TO a;',
++                    postgres._psql_prepare_and_run.call_args[0][0][1],
++                )
++                assert not postgres.create_extension("foo", ext_version="a", schema="b")
++                assert not postgres.create_extension("foo", ext_version="a", schema="b")
++
++
++def test_encrypt_passwords():
++    assert postgres._maybe_encrypt_password("foo", "bar", False) == "bar"
++    assert (
++        postgres._maybe_encrypt_password("foo", "bar", True)
++        == "md596948aad3fcae80c08a35c9b5958cd89"
++    )
++
++
++def test_schema_list(get_test_list_schema_csv):
++    with patch(
++        "salt.modules.postgres._run_psql",
++        Mock(return_value={"retcode": 0, "stdout": get_test_list_schema_csv}),
++    ):
++        ret = postgres.schema_list(
++            "maint_db",
++            db_user="testuser",
++            db_host="testhost",
++            db_port="testport",
++            db_password="foo",
++        )
++        assert ret == {
++            "public": {
++                "acl": "{postgres=UC/postgres,=UC/postgres}",
++                "owner": "postgres",
++            },
++            "pg_toast": {"acl": "", "owner": "postgres"},
++        }
++
++
++def test_schema_exists():
++    with patch("salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})):
++        with patch(
++            "salt.modules.postgres.psql_query",
++            Mock(
++                return_value=[
++                    {
++                        "name": "public",
++                        "acl": "{postgres=UC/postgres,=UC/postgres}",
++                        "owner": "postgres",
++                    }
++                ]
++            ),
++        ):
++            ret = postgres.schema_exists("template1", "public")
++            assert ret is True
++
++
++def test_schema_get():
++    with patch("salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})):
++        with patch(
++            "salt.modules.postgres.psql_query",
++            Mock(
++                return_value=[
++                    {
++                        "name": "public",
++                        "acl": "{postgres=UC/postgres,=UC/postgres}",
++                        "owner": "postgres",
++                    }
++                ]
++            ),
++        ):
++            ret = postgres.schema_get("template1", "public")
++            assert ret == {
++                "acl": "{postgres=UC/postgres,=UC/postgres}",
++                "owner": "postgres",
++            }
++
++
++def test_schema_get_again():
++    with patch("salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})):
++        with patch(
++            "salt.modules.postgres.psql_query",
++            Mock(
++                return_value=[
++                    {
++                        "name": "public",
++                        "acl": "{postgres=UC/postgres,=UC/postgres}",
++                        "owner": "postgres",
++                    }
++                ]
++            ),
++        ):
++            ret = postgres.schema_get("template1", "pg_toast")
++            assert ret is None
++
++
++def test_schema_create():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        with patch("salt.modules.postgres.schema_exists", Mock(return_value=False)):
++            postgres.schema_create(
++                "maint_db",
++                "testschema",
++                user="user",
++                db_host="testhost",
++                db_port="testport",
++                db_user="testuser",
++                db_password="testpassword",
++            )
++            postgres._run_psql.assert_called_once_with(
++                [
++                    "/usr/bin/pgsql",
++                    "--no-align",
++                    "--no-readline",
++                    "--no-psqlrc",
++                    "--no-password",
++                    "--username",
++                    "testuser",
++                    "--host",
++                    "testhost",
++                    "--port",
++                    "testport",
++                    "--dbname",
++                    "maint_db",
++                    "-c",
++                    'CREATE SCHEMA "testschema"',
++                ],
++                host="testhost",
++                port="testport",
++                password="testpassword",
++                user="testuser",
++                runas="user",
++            )
++
++
++def test_schema_create2():
++    with patch("salt.modules.postgres.schema_exists", Mock(return_value=True)):
++        ret = postgres.schema_create(
++            "test_db",
++            "test_schema",
++            user="user",
++            db_host="test_host",
++            db_port="test_port",
++            db_user="test_user",
++            db_password="test_password",
++        )
++        assert ret is False
++
++
++def test_schema_remove():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        with patch("salt.modules.postgres.schema_exists", Mock(return_value=True)):
++            postgres.schema_remove(
++                "maint_db",
++                "testschema",
++                user="user",
++                db_host="testhost",
++                db_port="testport",
++                db_user="testuser",
++                db_password="testpassword",
++            )
++            postgres._run_psql.assert_called_once_with(
++                [
++                    "/usr/bin/pgsql",
++                    "--no-align",
++                    "--no-readline",
++                    "--no-psqlrc",
++                    "--no-password",
++                    "--username",
++                    "testuser",
++                    "--host",
++                    "testhost",
++                    "--port",
++                    "testport",
++                    "--dbname",
++                    "maint_db",
++                    "-c",
++                    'DROP SCHEMA "testschema"',
++                ],
++                host="testhost",
++                port="testport",
++                password="testpassword",
++                user="testuser",
++                runas="user",
++            )
++
++
++def test_schema_remove2():
++    with patch("salt.modules.postgres.schema_exists", Mock(return_value=False)):
++        ret = postgres.schema_remove(
++            "test_db",
++            "test_schema",
++            user="user",
++            db_host="test_host",
++            db_port="test_port",
++            db_user="test_user",
++            db_password="test_password",
++        )
++        assert ret is False
++
++
++def test_language_list(get_test_list_language_csv):
++    """
++    Test language listing
++    """
++    with patch(
++        "salt.modules.postgres._run_psql",
++        Mock(return_value={"retcode": 0, "stdout": get_test_list_language_csv}),
++    ):
++        ret = postgres.language_list(
++            "testdb",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            password="foo",
++        )
++        assert ret == {
++            "c": "c",
++            "internal": "internal",
++            "plpgsql": "plpgsql",
++            "sql": "sql",
++        }
++
++
++def test_language_exists():
++    """
++    Test language existence check
++    """
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch(
++        "salt.modules.postgres.psql_query",
++        Mock(
++            return_value=[
++                {"Name": "internal"},
++                {"Name": "c"},
++                {"Name": "sql"},
++                {"Name": "plpgsql"},
++            ]
++        ),
++    ), patch(
++        "salt.modules.postgres.language_exists", Mock(return_value=True)
++    ):
++        ret = postgres.language_exists("sql", "testdb")
++        assert ret is True
++
++
++def test_language_create():
++    """
++    Test language creation - does not exist in db
++    """
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        with patch("salt.modules.postgres.language_exists", Mock(return_value=False)):
++            postgres.language_create(
++                "plpythonu",
++                "testdb",
++                runas="user",
++                host="testhost",
++                port="testport",
++                user="testuser",
++                password="testpassword",
++            )
++            postgres._run_psql.assert_called_once_with(
++                [
++                    "/usr/bin/pgsql",
++                    "--no-align",
++                    "--no-readline",
++                    "--no-psqlrc",
++                    "--no-password",
++                    "--username",
++                    "testuser",
++                    "--host",
++                    "testhost",
++                    "--port",
++                    "testport",
++                    "--dbname",
++                    "testdb",
++                    "-c",
++                    "CREATE LANGUAGE plpythonu",
++                ],
++                host="testhost",
++                port="testport",
++                password="testpassword",
++                user="testuser",
++                runas="user",
++            )
++
++
++def test_language_create_exists():
++    """
++    Test language creation - already exists in db
++    """
++    with patch("salt.modules.postgres.language_exists", Mock(return_value=True)):
++        ret = postgres.language_create(
++            "plpythonu",
++            "testdb",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++        assert ret is False
++
++
++def test_language_remove():
++    """
++    Test language removal - exists in db
++    """
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        with patch("salt.modules.postgres.language_exists", Mock(return_value=True)):
++            postgres.language_remove(
++                "plpgsql",
++                "testdb",
++                runas="user",
++                host="testhost",
++                port="testport",
++                user="testuser",
++                password="testpassword",
++            )
++            postgres._run_psql.assert_called_once_with(
++                [
++                    "/usr/bin/pgsql",
++                    "--no-align",
++                    "--no-readline",
++                    "--no-psqlrc",
++                    "--no-password",
++                    "--username",
++                    "testuser",
++                    "--host",
++                    "testhost",
++                    "--port",
++                    "testport",
++                    "--dbname",
++                    "testdb",
++                    "-c",
++                    "DROP LANGUAGE plpgsql",
++                ],
++                host="testhost",
++                port="testport",
++                password="testpassword",
++                user="testuser",
++                runas="user",
++            )
++
++
++def test_language_remove_non_exist():
++    """
++    Test language removal - does not exist in db
++    """
++    with patch("salt.modules.postgres.language_exists", Mock(return_value=False)):
++        ret = postgres.language_remove(
++            "plpgsql",
++            "testdb",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++        assert ret is False
++
++
++def test_privileges_list_table(get_test_privileges_list_table_csv):
++    """
++    Test privilege listing on a table
++    """
++    with patch(
++        "salt.modules.postgres._run_psql",
++        Mock(return_value={"retcode": 0, "stdout": get_test_privileges_list_table_csv}),
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        ret = postgres.privileges_list(
++            "awl",
++            "table",
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++        expected = {
++            "bayestest": {
++                "INSERT": False,
++                "UPDATE": False,
++                "SELECT": False,
++                "DELETE": False,
++            },
++            "baruwa": {
++                "INSERT": True,
++                "TRUNCATE": True,
++                "UPDATE": True,
++                "TRIGGER": True,
++                "REFERENCES": True,
++                "SELECT": True,
++                "DELETE": True,
++                "MAINTAIN": True,
++            },
++            "baruwatest": {
++                "INSERT": False,
++                "TRUNCATE": False,
++                "UPDATE": False,
++                "TRIGGER": False,
++                "REFERENCES": False,
++                "SELECT": False,
++                "DELETE": False,
++                "MAINTAIN": False,
++            },
++        }
++        assert ret == expected
++
++        query = (
++            "COPY (SELECT relacl AS name FROM pg_catalog.pg_class c "
++            "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
++            "WHERE nspname = 'public' AND relname = 'awl' AND relkind in ('r', 'v') "
++            "ORDER BY relname) TO STDOUT WITH CSV HEADER"
++        )
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "db_name",
++                "-v",
++                "datestyle=ISO,MDY",
++                "-c",
++                query,
++            ],
++            host="testhost",
++            port="testport",
++            password="testpassword",
++            user="testuser",
++            runas="user",
++        )
++
++
++def test_privileges_list_group(get_test_privileges_list_group_csv):
++    """
++    Test privilege listing on a group
++    """
++    with patch(
++        "salt.modules.postgres._run_psql",
++        Mock(return_value={"retcode": 0, "stdout": get_test_privileges_list_group_csv}),
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        ret = postgres.privileges_list(
++            "admin",
++            "group",
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++        expected = {
++            "baruwa": False,
++            "baruwatest": False,
++            "baruwatest2": True,
++        }
++        assert ret == expected
++
++        query = (
++            "COPY (SELECT rolname, admin_option "
++            "FROM pg_catalog.pg_auth_members m JOIN pg_catalog.pg_roles r "
++            "ON m.member=r.oid WHERE m.roleid IN (SELECT oid FROM "
++            "pg_catalog.pg_roles WHERE rolname='admin') ORDER BY rolname) "
++            "TO STDOUT WITH CSV HEADER"
++        )
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "db_name",
++                "-v",
++                "datestyle=ISO,MDY",
++                "-c",
++                query,
++            ],
++            host="testhost",
++            port="testport",
++            password="testpassword",
++            user="testuser",
++            runas="user",
++        )
++
++
++def test_has_privileges_on_table(get_test_privileges_list_table_csv):
++    """
++    Test privilege checks on table
++    """
++    with patch(
++        "salt.modules.postgres._run_psql",
++        Mock(return_value={"retcode": 0, "stdout": get_test_privileges_list_table_csv}),
++    ):
++        ret = postgres.has_privileges(
++            "baruwa",
++            "awl",
++            "table",
++            "SELECT,INSERT",
++            grant_option=True,
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++        assert ret is True
++
++        ret = postgres.has_privileges(
++            "baruwa",
++            "awl",
++            "table",
++            "ALL",
++            grant_option=True,
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++        assert ret is True
++
++        ret = postgres.has_privileges(
++            "baruwa",
++            "awl",
++            "table",
++            "ALL",
++            grant_option=False,
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++        assert ret is True
++
++        ret = postgres.has_privileges(
++            "bayestest",
++            "awl",
++            "table",
++            "SELECT,INSERT,TRUNCATE",
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++        assert ret is False
++
++        ret = postgres.has_privileges(
++            "bayestest",
++            "awl",
++            "table",
++            "SELECT,INSERT",
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++        assert ret is True
++
++
++def test_has_privileges_on_group(get_test_privileges_list_group_csv):
++    """
++    Test privilege checks on group
++    """
++    with patch(
++        "salt.modules.postgres._run_psql",
++        Mock(return_value={"retcode": 0, "stdout": get_test_privileges_list_group_csv}),
++    ):
++        ret = postgres.has_privileges(
++            "baruwa",
++            "admin",
++            "group",
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++        assert ret is True
++
++        ret = postgres.has_privileges(
++            "baruwa",
++            "admin",
++            "group",
++            grant_option=True,
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++        assert ret is False
++
++        ret = postgres.has_privileges(
++            "tony",
++            "admin",
++            "group",
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++        assert ret is False
++
++
++def test_privileges_grant_table():
++    """
++    Test granting privileges on table
++    """
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        with patch("salt.modules.postgres.has_privileges", Mock(return_value=False)):
++            ret = postgres.privileges_grant(
++                "baruwa",
++                "awl",
++                "table",
++                "ALL",
++                grant_option=True,
++                maintenance_db="db_name",
++                runas="user",
++                host="testhost",
++                port="testport",
++                user="testuser",
++                password="testpassword",
++            )
++
++            query = 'GRANT ALL ON TABLE public."awl" TO "baruwa" WITH GRANT OPTION'
++
++            postgres._run_psql.assert_called_once_with(
++                [
++                    "/usr/bin/pgsql",
++                    "--no-align",
++                    "--no-readline",
++                    "--no-psqlrc",
++                    "--no-password",
++                    "--username",
++                    "testuser",
++                    "--host",
++                    "testhost",
++                    "--port",
++                    "testport",
++                    "--dbname",
++                    "db_name",
++                    "-c",
++                    query,
++                ],
++                host="testhost",
++                port="testport",
++                password="testpassword",
++                user="testuser",
++                runas="user",
++            )
++
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
++        "salt.modules.postgres.has_privileges", Mock(return_value=False)
++    ):
++        ret = postgres.privileges_grant(
++            "baruwa",
++            "awl",
++            "table",
++            "ALL",
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++
++        query = 'GRANT ALL ON TABLE public."awl" TO "baruwa"'
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "db_name",
++                "-c",
++                query,
++            ],
++            host="testhost",
++            port="testport",
++            password="testpassword",
++            user="testuser",
++            runas="user",
++        )
++
++    # Test grant on all tables
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
++        "salt.modules.postgres.has_privileges", Mock(return_value=False)
++    ):
++        ret = postgres.privileges_grant(
++            "baruwa",
++            "ALL",
++            "table",
++            "SELECT",
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++
++        query = 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "baruwa"'
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "db_name",
++                "-c",
++                query,
++            ],
++            host="testhost",
++            port="testport",
++            password="testpassword",
++            user="testuser",
++            runas="user",
++        )
++
++
++def test_privileges_grant_group():
++    """
++    Test granting privileges on group
++    """
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
++        "salt.modules.postgres.has_privileges", Mock(return_value=False)
++    ):
++        ret = postgres.privileges_grant(
++            "baruwa",
++            "admins",
++            "group",
++            grant_option=True,
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++
++        query = 'GRANT admins TO "baruwa" WITH ADMIN OPTION'
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "db_name",
++                "-c",
++                query,
++            ],
++            host="testhost",
++            port="testport",
++            password="testpassword",
++            user="testuser",
++            runas="user",
++        )
++
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
++        "salt.modules.postgres.has_privileges", Mock(return_value=False)
++    ):
++        ret = postgres.privileges_grant(
++            "baruwa",
++            "admins",
++            "group",
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++
++        query = 'GRANT admins TO "baruwa"'
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "db_name",
++                "-c",
++                query,
++            ],
++            host="testhost",
++            port="testport",
++            password="testpassword",
++            user="testuser",
++            runas="user",
++        )
++
++
++def test_privileges_revoke_table():
++    """
++    Test revoking privileges on table
++    """
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
++        "salt.modules.postgres.has_privileges", Mock(return_value=True)
++    ):
++        ret = postgres.privileges_revoke(
++            "baruwa",
++            "awl",
++            "table",
++            "ALL",
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++
++        query = "REVOKE ALL ON TABLE public.awl FROM baruwa"
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "db_name",
++                "-c",
++                query,
++            ],
++            host="testhost",
++            port="testport",
++            password="testpassword",
++            user="testuser",
++            runas="user",
++        )
++
++
++def test_privileges_revoke_group():
++    """
++    Test revoking privileges on group
++    """
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")), patch(
++        "salt.modules.postgres.has_privileges", Mock(return_value=True)
++    ):
++        ret = postgres.privileges_revoke(
++            "baruwa",
++            "admins",
++            "group",
++            maintenance_db="db_name",
++            runas="user",
++            host="testhost",
++            port="testport",
++            user="testuser",
++            password="testpassword",
++        )
++
++        query = "REVOKE admins FROM baruwa"
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "db_name",
++                "-c",
++                query,
++            ],
++            host="testhost",
++            port="testport",
++            password="testpassword",
++            user="testuser",
++            runas="user",
++        )
++
++
++def test_datadir_init():
++    """
++    Test Initializing a postgres data directory
++    """
++    with patch("salt.modules.postgres._run_initdb", Mock(return_value={"retcode": 0})):
++        with patch("salt.modules.postgres.datadir_exists", Mock(return_value=False)):
++            name = "/var/lib/pgsql/data"
++            ret = postgres.datadir_init(
++                name, user="postgres", password="test", runas="postgres"
++            )
++            postgres._run_initdb.assert_called_once_with(
++                name,
++                auth="password",
++                encoding="UTF8",
++                locale=None,
++                password="test",
++                runas="postgres",
++                checksums=False,
++                waldir=None,
++                user="postgres",
++            )
++            assert ret is True
++
++
++def test_datadir_exists():
++    """
++    Test Checks if postgres data directory has been initialized
++    """
++    with patch("os.path.isfile", Mock(return_value=True)):
++        name = "/var/lib/pgsql/data"
++        ret = postgres.datadir_exists(name)
++        assert ret is True
++
++
++@pytest.mark.parametrize(
++    "v1,v2,result",
++    (
++        ("8.5", "9.5", True),
++        ("8.5", "8.6", True),
++        ("8.5.2", "8.5.3", True),
++        ("9.5", "8.5", False),
++        ("9.5", "9.6", True),
++        ("9.5.0", "9.5.1", True),
++        ("9.5", "9.5.1", True),
++        ("9.5.1", "9.5", False),
++        ("9.5b", "9.5a", False),
++        ("10a", "10b", True),
++        ("1.2.3.4", "1.2.3.5", True),
++        ("10dev", "10next", True),
++        ("10next", "10dev", False),
++    ),
++)
++def test_pg_is_older_ext_ver(v1, v2, result):
++    """
++    Test Checks if postgres extension version string is older
++    """
++    assert postgres._pg_is_older_ext_ver(v1, v2) is result
++
++
++def test_tablespace_create():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        postgres.tablespace_create(
++            "test_tablespace",
++            "/tmp/postgres_test_tablespace",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            owner="otheruser",
++            runas="foo",
++        )
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "maint_db",
++                "-c",
++                'CREATE TABLESPACE "test_tablespace" OWNER "otheruser" LOCATION \'/tmp/postgres_test_tablespace\' ',
++            ],
++            runas="foo",
++            password="foo",
++            host="testhost",
++            port="testport",
++            user="testuser",
++        )
++
++
++def test_tablespace_list():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch(
++        "salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")
++    ), patch.dict(
++        postgres.__salt__,
++        {
++            "postgres.psql_query": MagicMock(
++                return_value=[
++                    {
++                        "Name": "pg_global",
++                        "Owner": "postgres",
++                        "ACL": "",
++                        "Opts": "",
++                        "Location": "",
++                    },
++                    {
++                        "Name": "pg_default",
++                        "Owner": "postgres",
++                        "ACL": "",
++                        "Opts": "",
++                        "Location": "",
++                    },
++                    {
++                        "Name": "test_tablespace",
++                        "Owner": "testuser",
++                        "ACL": "",
++                        "Opts": "",
++                        "Location": "/tmp/posgrest_test_tablespace",
++                    },
++                ]
++            ),
++        },
++    ):
++        ret = postgres.tablespace_list(
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            runas="foo",
++        )
++
++        expected_data = {
++            "pg_global": {"Owner": "postgres", "ACL": "", "Opts": "", "Location": ""},
++            "pg_default": {"Owner": "postgres", "ACL": "", "Opts": "", "Location": ""},
++            "test_tablespace": {
++                "Owner": "testuser",
++                "ACL": "",
++                "Opts": "",
++                "Location": "/tmp/posgrest_test_tablespace",
++            },
++        }
++        assert ret == expected_data
++
++
++def test_tablespace_exists_true():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch(
++        "salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")
++    ), patch.dict(
++        postgres.__salt__,
++        {
++            "postgres.psql_query": MagicMock(
++                return_value=[
++                    {
++                        "Name": "pg_global",
++                        "Owner": "postgres",
++                        "ACL": "",
++                        "Opts": "",
++                        "Location": "",
++                    },
++                    {
++                        "Name": "pg_default",
++                        "Owner": "postgres",
++                        "ACL": "",
++                        "Opts": "",
++                        "Location": "",
++                    },
++                    {
++                        "Name": "test_tablespace",
++                        "Owner": "testuser",
++                        "ACL": "",
++                        "Opts": "",
++                        "Location": "/tmp/posgrest_test_tablespace",
++                    },
++                ]
++            ),
++        },
++    ):
++        ret = postgres.tablespace_exists(
++            "test_tablespace",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            runas="foo",
++        )
++        assert ret is True
++
++
++def test_tablespace_exists_false():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch(
++        "salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")
++    ), patch.dict(
++        postgres.__salt__,
++        {
++            "postgres.psql_query": MagicMock(
++                return_value=[
++                    {
++                        "Name": "pg_global",
++                        "Owner": "postgres",
++                        "ACL": "",
++                        "Opts": "",
++                        "Location": "",
++                    },
++                    {
++                        "Name": "pg_default",
++                        "Owner": "postgres",
++                        "ACL": "",
++                        "Opts": "",
++                        "Location": "",
++                    },
++                    {
++                        "Name": "test_tablespace",
++                        "Owner": "testuser",
++                        "ACL": "",
++                        "Opts": "",
++                        "Location": "/tmp/posgrest_test_tablespace",
++                    },
++                ]
++            ),
++        },
++    ):
++        ret = postgres.tablespace_exists(
++            "bad_test_tablespace",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            runas="foo",
++        )
++        assert ret is False
++
++
++def test_tablespace_alter_new_owner():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        postgres.tablespace_alter(
++            "test_tablespace",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            runas="foo",
++            new_owner="testuser",
++        )
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "maint_db",
++                "-c",
++                'ALTER TABLESPACE "test_tablespace" OWNER TO "testuser"',
++            ],
++            runas="foo",
++            password="foo",
++            host="testhost",
++            port="testport",
++            user="testuser",
++        )
++
++
++def test_tablespace_alter_new_name():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        postgres.tablespace_alter(
++            "test_tablespace",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            runas="foo",
++            new_name="test_tablespace2",
++        )
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "maint_db",
++                "-c",
++                'ALTER TABLESPACE "test_tablespace" RENAME TO "test_tablespace2"',
++            ],
++            runas="foo",
++            password="foo",
++            host="testhost",
++            port="testport",
++            user="testuser",
++        )
++
++
++def test_tablespace_remove():
++    with patch(
++        "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
++    ), patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/pgsql")):
++        postgres.tablespace_remove(
++            "test_tablespace",
++            user="testuser",
++            host="testhost",
++            port="testport",
++            maintenance_db="maint_db",
++            password="foo",
++            runas="foo",
++        )
++
++        postgres._run_psql.assert_called_once_with(
++            [
++                "/usr/bin/pgsql",
++                "--no-align",
++                "--no-readline",
++                "--no-psqlrc",
++                "--no-password",
++                "--username",
++                "testuser",
++                "--host",
++                "testhost",
++                "--port",
++                "testport",
++                "--dbname",
++                "maint_db",
++                "-c",
++                'DROP TABLESPACE "test_tablespace"',
++            ],
++            runas="foo",
++            password="foo",
++            host="testhost",
++            port="testport",
++            user="testuser",
++        )
+diff --git a/tests/unit/modules/test_deb_postgres.py b/tests/unit/modules/test_deb_postgres.py
+deleted file mode 100644
+index 37e276fdff..0000000000
+--- a/tests/unit/modules/test_deb_postgres.py
++++ /dev/null
+@@ -1,184 +0,0 @@
+-import salt.modules.deb_postgres as deb_postgres
+-from tests.support.mixins import LoaderModuleMockMixin
+-from tests.support.mock import Mock, patch
+-from tests.support.unit import TestCase
+-
+-LSCLUSTER = """\
+-8.4 main 5432 online postgres /srv/8.4/main \
+-        /var/log/postgresql/postgresql-8.4-main.log
+-9.1 main 5433 online postgres /srv/9.1/main \
+-        /var/log/postgresql/postgresql-9.1-main.log
+-"""
+-
+-
+-class PostgresClusterTestCase(TestCase, LoaderModuleMockMixin):
+-    def setup_loader_modules(self):
+-        self.cmd_run_all_mock = Mock(return_value={"stdout": LSCLUSTER})
+-        self.addCleanup(delattr, self, "cmd_run_all_mock")
+-        patcher = patch(
+-            "salt.utils.path.which", Mock(return_value="/usr/bin/pg_createcluster")
+-        )
+-        patcher.start()
+-        self.addCleanup(patcher.stop)
+-        return {
+-            deb_postgres: {
+-                "__salt__": {
+-                    "config.option": Mock(),
+-                    "cmd.run_all": self.cmd_run_all_mock,
+-                    "file.chown": Mock(),
+-                    "file.remove": Mock(),
+-                }
+-            }
+-        }
+-
+-    def test_cluster_create(self):
+-        deb_postgres.cluster_create(
+-            "9.3",
+-            "main",
+-            port="5432",
+-            locale="fr_FR",
+-            encoding="UTF-8",
+-            datadir="/opt/postgresql",
+-        )
+-        cmdstr = (
+-            "/usr/bin/pg_createcluster "
+-            "--port 5432 --locale fr_FR --encoding UTF-8 "
+-            "--datadir /opt/postgresql "
+-            "9.3 main"
+-        )
+-        self.assertEqual(cmdstr, self.cmd_run_all_mock.call_args[0][0])
+-
+-    def test_cluster_create_with_initdb_options(self):
+-        deb_postgres.cluster_create(
+-            "11",
+-            "main",
+-            port="5432",
+-            locale="fr_FR",
+-            encoding="UTF-8",
+-            datadir="/opt/postgresql",
+-            allow_group_access=True,
+-            data_checksums=True,
+-            wal_segsize="32",
+-        )
+-        cmdstr = (
+-            "/usr/bin/pg_createcluster "
+-            "--port 5432 --locale fr_FR --encoding UTF-8 "
+-            "--datadir /opt/postgresql "
+-            "11 main "
+-            "-- "
+-            "--allow-group-access "
+-            "--data-checksums "
+-            "--wal-segsize 32"
+-        )
+-        self.assertEqual(cmdstr, self.cmd_run_all_mock.call_args[0][0])
+-
+-    def test_cluster_create_with_float(self):
+-        deb_postgres.cluster_create(
+-            9.3,
+-            "main",
+-            port="5432",
+-            locale="fr_FR",
+-            encoding="UTF-8",
+-            datadir="/opt/postgresql",
+-        )
+-        cmdstr = (
+-            "/usr/bin/pg_createcluster "
+-            "--port 5432 --locale fr_FR --encoding UTF-8 "
+-            "--datadir /opt/postgresql "
+-            "9.3 main"
+-        )
+-        self.assertEqual(cmdstr, self.cmd_run_all_mock.call_args[0][0])
+-
+-
+-class PostgresLsClusterTestCase(TestCase, LoaderModuleMockMixin):
+-    def setup_loader_modules(self):
+-        self.cmd_run_all_mock = Mock(return_value={"stdout": LSCLUSTER})
+-        self.addCleanup(delattr, self, "cmd_run_all_mock")
+-        patcher = patch(
+-            "salt.utils.path.which", Mock(return_value="/usr/bin/pg_lsclusters")
+-        )
+-        patcher.start()
+-        self.addCleanup(patcher.stop)
+-        return {
+-            deb_postgres: {
+-                "__salt__": {
+-                    "config.option": Mock(),
+-                    "cmd.run_all": self.cmd_run_all_mock,
+-                    "file.chown": Mock(),
+-                    "file.remove": Mock(),
+-                }
+-            }
+-        }
+-
+-    def test_parse_pg_lsclusters(self):
+-        stdout = LSCLUSTER
+-        self.maxDiff = None
+-        self.assertDictEqual(
+-            {
+-                "8.4/main": {
+-                    "port": 5432,
+-                    "status": "online",
+-                    "user": "postgres",
+-                    "datadir": "/srv/8.4/main",
+-                    "log": "/var/log/postgresql/postgresql-8.4-main.log",
+-                },
+-                "9.1/main": {
+-                    "port": 5433,
+-                    "status": "online",
+-                    "user": "postgres",
+-                    "datadir": "/srv/9.1/main",
+-                    "log": "/var/log/postgresql/postgresql-9.1-main.log",
+-                },
+-            },
+-            deb_postgres._parse_pg_lscluster(stdout),
+-        )
+-
+-    def test_cluster_list(self):
+-        return_list = deb_postgres.cluster_list()
+-        self.assertEqual(
+-            "/usr/bin/pg_lsclusters --no-header", self.cmd_run_all_mock.call_args[0][0]
+-        )
+-        return_dict = deb_postgres.cluster_list(verbose=True)
+-        self.assertIsInstance(return_dict, dict)
+-
+-    def test_cluster_exists(self):
+-        self.assertTrue(deb_postgres.cluster_exists("8.4") is True)
+-        self.assertTrue(deb_postgres.cluster_exists("8.4", "main") is True)
+-        self.assertFalse(deb_postgres.cluster_exists("3.4", "main"))
+-
+-
+-class PostgresDeleteClusterTestCase(TestCase, LoaderModuleMockMixin):
+-    def setup_loader_modules(self):
+-        self.cmd_run_all_mock = Mock(return_value={"stdout": LSCLUSTER})
+-        self.addCleanup(delattr, self, "cmd_run_all_mock")
+-        patcher = patch(
+-            "salt.utils.path.which", Mock(return_value="/usr/bin/pg_dropcluster")
+-        )
+-        patcher.start()
+-        self.addCleanup(patcher.stop)
+-        return {
+-            deb_postgres: {
+-                "__salt__": {
+-                    "config.option": Mock(),
+-                    "cmd.run_all": self.cmd_run_all_mock,
+-                    "file.chown": Mock(),
+-                    "file.remove": Mock(),
+-                }
+-            }
+-        }
+-
+-    def test_cluster_delete(self):
+-        deb_postgres.cluster_remove("9.3", "main")
+-        self.assertEqual(
+-            "/usr/bin/pg_dropcluster 9.3 main", self.cmd_run_all_mock.call_args[0][0]
+-        )
+-        deb_postgres.cluster_remove("9.3", "main", stop=True)
+-        self.assertEqual(
+-            "/usr/bin/pg_dropcluster --stop 9.3 main",
+-            self.cmd_run_all_mock.call_args[0][0],
+-        )
+-        deb_postgres.cluster_remove(9.3, "main", stop=True)
+-        self.assertEqual(
+-            "/usr/bin/pg_dropcluster --stop 9.3 main",
+-            self.cmd_run_all_mock.call_args[0][0],
+-        )
+diff --git a/tests/unit/modules/test_postgres.py b/tests/unit/modules/test_postgres.py
+deleted file mode 100644
+index 6f77fc0390..0000000000
+--- a/tests/unit/modules/test_postgres.py
++++ /dev/null
+@@ -1,2086 +0,0 @@
+-import datetime
+-import logging
+-import re
+-
+-import salt.modules.postgres as postgres
+-from salt.exceptions import SaltInvocationError
+-from tests.support.mixins import LoaderModuleMockMixin
+-from tests.support.mock import Mock, call, patch
+-from tests.support.unit import TestCase
+-
+-test_list_db_csv = (
+-    "Name,Owner,Encoding,Collate,Ctype,Access privileges,Tablespace\n"
+-    "template1,postgres,LATIN1,en_US,en_US"
+-    ',"{=c/postgres,postgres=CTc/postgres}",pg_default\n'
+-    "template0,postgres,LATIN1,en_US,en_US"
+-    ',"{=c/postgres,postgres=CTc/postgres}",pg_default\n'
+-    "postgres,postgres,LATIN1,en_US,en_US,,pg_default\n"
+-    "test_db,postgres,LATIN1,en_US,en_US,,pg_default"
+-)
+-
+-test_list_schema_csv = (
+-    "name,owner,acl\n"
+-    'public,postgres,"{postgres=UC/postgres,=UC/postgres}"\n'
+-    'pg_toast,postgres,""'
+-)
+-
+-test_list_language_csv = "Name\ninternal\nc\nsql\nplpgsql\n"
+-
+-test_privileges_list_table_csv = (
+-    "name\n"
+-    '"{baruwatest=arwdDxt/baruwatest,bayestest=arwd/baruwatest,baruwa=a*r*w*d*D*x*t*/baruwatest}"\n'
+-)
+-
+-test_privileges_list_group_csv = (
+-    "rolname,admin_option\nbaruwa,f\nbaruwatest2,t\nbaruwatest,f\n"
+-)
+-
+-log = logging.getLogger(__name__)
+-
+-
+-class PostgresTestCase(TestCase, LoaderModuleMockMixin):
+-    def setup_loader_modules(self):
+-        patcher = patch("salt.utils.path.which", Mock(return_value="/usr/bin/pgsql"))
+-        patcher.start()
+-        self.addCleanup(patcher.stop)
+-        return {
+-            postgres: {
+-                "__grains__": {"os_family": "Linux"},
+-                "__salt__": {
+-                    "config.option": Mock(),
+-                    "cmd.run_all": Mock(),
+-                    "file.chown": Mock(),
+-                    "file.remove": Mock(),
+-                },
+-            }
+-        }
+-
+-    def test_run_psql(self):
+-        postgres._run_psql('echo "hi"')
+-        cmd = postgres.__salt__["cmd.run_all"]
+-
+-        self.assertEqual("postgres", cmd.call_args[1]["runas"])
+-
+-    def test_db_alter(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            postgres.db_alter(
+-                "dbname",
+-                user="testuser",
+-                host="testhost",
+-                port="testport",
+-                maintenance_db="maint_db",
+-                password="foo",
+-                tablespace="testspace",
+-                owner="otheruser",
+-                runas="foo",
+-            )
+-            postgres._run_psql.assert_has_calls(
+-                [
+-                    call(
+-                        [
+-                            "/usr/bin/pgsql",
+-                            "--no-align",
+-                            "--no-readline",
+-                            "--no-psqlrc",
+-                            "--no-password",
+-                            "--username",
+-                            "testuser",
+-                            "--host",
+-                            "testhost",
+-                            "--port",
+-                            "testport",
+-                            "--dbname",
+-                            "maint_db",
+-                            "-c",
+-                            'ALTER DATABASE "dbname" OWNER TO "otheruser"',
+-                        ],
+-                        host="testhost",
+-                        user="testuser",
+-                        password="foo",
+-                        runas="foo",
+-                        port="testport",
+-                    ),
+-                    call(
+-                        [
+-                            "/usr/bin/pgsql",
+-                            "--no-align",
+-                            "--no-readline",
+-                            "--no-psqlrc",
+-                            "--no-password",
+-                            "--username",
+-                            "testuser",
+-                            "--host",
+-                            "testhost",
+-                            "--port",
+-                            "testport",
+-                            "--dbname",
+-                            "maint_db",
+-                            "-c",
+-                            'ALTER DATABASE "dbname" SET TABLESPACE "testspace"',
+-                        ],
+-                        host="testhost",
+-                        user="testuser",
+-                        password="foo",
+-                        runas="foo",
+-                        port="testport",
+-                    ),
+-                ]
+-            )
+-
+-    def test_db_alter_owner_recurse(self):
+-        with patch(
+-            "salt.modules.postgres.owner_to", Mock(return_value={"retcode": None})
+-        ):
+-            postgres.db_alter(
+-                "dbname",
+-                user="testuser",
+-                host="testhost",
+-                port="testport",
+-                maintenance_db="maint_db",
+-                password="foo",
+-                tablespace="testspace",
+-                owner="otheruser",
+-                owner_recurse=True,
+-                runas="foo",
+-            )
+-            postgres.owner_to.assert_called_once_with(
+-                "dbname",
+-                "otheruser",
+-                user="testuser",
+-                host="testhost",
+-                port="testport",
+-                password="foo",
+-                runas="foo",
+-            )
+-
+-    def test_db_create(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            postgres.db_create(
+-                "dbname",
+-                user="testuser",
+-                host="testhost",
+-                port="testport",
+-                maintenance_db="maint_db",
+-                password="foo",
+-                tablespace="testspace",
+-                owner="otheruser",
+-                runas="foo",
+-            )
+-
+-            postgres._run_psql.assert_called_once_with(
+-                [
+-                    "/usr/bin/pgsql",
+-                    "--no-align",
+-                    "--no-readline",
+-                    "--no-psqlrc",
+-                    "--no-password",
+-                    "--username",
+-                    "testuser",
+-                    "--host",
+-                    "testhost",
+-                    "--port",
+-                    "testport",
+-                    "--dbname",
+-                    "maint_db",
+-                    "-c",
+-                    'CREATE DATABASE "dbname" WITH TABLESPACE = "testspace" '
+-                    'OWNER = "otheruser"',
+-                ],
+-                host="testhost",
+-                user="testuser",
+-                password="foo",
+-                runas="foo",
+-                port="testport",
+-            )
+-
+-    def test_db_create_empty_string_param(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            postgres.db_create(
+-                "dbname",
+-                lc_collate="",
+-                encoding="utf8",
+-                user="testuser",
+-                host="testhost",
+-                port=1234,
+-                maintenance_db="maint_db",
+-                password="foo",
+-            )
+-
+-            postgres._run_psql.assert_called_once_with(
+-                [
+-                    "/usr/bin/pgsql",
+-                    "--no-align",
+-                    "--no-readline",
+-                    "--no-psqlrc",
+-                    "--no-password",
+-                    "--username",
+-                    "testuser",
+-                    "--host",
+-                    "testhost",
+-                    "--port",
+-                    "1234",
+-                    "--dbname",
+-                    "maint_db",
+-                    "-c",
+-                    "CREATE DATABASE \"dbname\" WITH ENCODING = 'utf8' LC_COLLATE = ''",
+-                ],
+-                host="testhost",
+-                password="foo",
+-                port=1234,
+-                runas=None,
+-                user="testuser",
+-            )
+-
+-    def test_db_create_with_trivial_sql_injection(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            self.assertRaises(
+-                SaltInvocationError,
+-                postgres.db_create,
+-                "dbname",
+-                lc_collate="foo' ENCODING='utf8",
+-            )
+-
+-    def test_db_exists(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql",
+-            Mock(return_value={"retcode": 0, "stdout": test_list_db_csv}),
+-        ):
+-            ret = postgres.db_exists(
+-                "test_db",
+-                user="testuser",
+-                host="testhost",
+-                port="testport",
+-                maintenance_db="maint_db",
+-                password="foo",
+-                runas="foo",
+-            )
+-            self.assertTrue(ret)
+-
+-    def test_db_list(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql",
+-            Mock(return_value={"retcode": 0, "stdout": test_list_db_csv}),
+-        ):
+-            ret = postgres.db_list(
+-                user="testuser",
+-                host="testhost",
+-                port="testport",
+-                maintenance_db="maint_db",
+-                password="foo",
+-                runas="foo",
+-            )
+-            self.assertDictEqual(
+-                ret,
+-                {
+-                    "test_db": {
+-                        "Encoding": "LATIN1",
+-                        "Ctype": "en_US",
+-                        "Tablespace": "pg_default",
+-                        "Collate": "en_US",
+-                        "Owner": "postgres",
+-                        "Access privileges": "",
+-                    },
+-                    "template1": {
+-                        "Encoding": "LATIN1",
+-                        "Ctype": "en_US",
+-                        "Tablespace": "pg_default",
+-                        "Collate": "en_US",
+-                        "Owner": "postgres",
+-                        "Access privileges": "{=c/postgres,postgres=CTc/postgres}",
+-                    },
+-                    "template0": {
+-                        "Encoding": "LATIN1",
+-                        "Ctype": "en_US",
+-                        "Tablespace": "pg_default",
+-                        "Collate": "en_US",
+-                        "Owner": "postgres",
+-                        "Access privileges": "{=c/postgres,postgres=CTc/postgres}",
+-                    },
+-                    "postgres": {
+-                        "Encoding": "LATIN1",
+-                        "Ctype": "en_US",
+-                        "Tablespace": "pg_default",
+-                        "Collate": "en_US",
+-                        "Owner": "postgres",
+-                        "Access privileges": "",
+-                    },
+-                },
+-            )
+-
+-    def test_db_remove(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            postgres.db_remove(
+-                "test_db",
+-                user="testuser",
+-                host="testhost",
+-                port="testport",
+-                maintenance_db="maint_db",
+-                password="foo",
+-                runas="foo",
+-            )
+-
+-            calls = (
+-                call(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "maint_db",
+-                        "-c",
+-                        'REVOKE CONNECT ON DATABASE "test_db" FROM public;',
+-                    ],
+-                    host="testhost",
+-                    password="foo",
+-                    port="testport",
+-                    runas="foo",
+-                    user="testuser",
+-                ),
+-                call(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "maint_db",
+-                        "-c",
+-                        "SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity"
+-                        " WHERE datname = 'test_db' AND pid <> pg_backend_pid();",
+-                    ],
+-                    host="testhost",
+-                    password="foo",
+-                    port="testport",
+-                    runas="foo",
+-                    user="testuser",
+-                ),
+-                call(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "maint_db",
+-                        "-c",
+-                        'DROP DATABASE "test_db";',
+-                    ],
+-                    host="testhost",
+-                    password="foo",
+-                    port="testport",
+-                    runas="foo",
+-                    user="testuser",
+-                ),
+-            )
+-
+-            postgres._run_psql.assert_has_calls(calls, any_order=True)
+-
+-    def test_group_create(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch("salt.modules.postgres.user_exists", Mock(return_value=False)):
+-                postgres.group_create(
+-                    "testgroup",
+-                    user="testuser",
+-                    host="testhost",
+-                    port="testport",
+-                    maintenance_db="maint_db",
+-                    password="foo",
+-                    createdb=False,
+-                    encrypted=False,
+-                    superuser=False,
+-                    replication=False,
+-                    rolepassword="testrolepass",
+-                    groups="testgroup",
+-                    runas="foo",
+-                )
+-                # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
+-                # The first 14 elements of this list are initial args used in all (or
+-                # virtually all) commands run through _run_psql(), so the actual SQL
+-                # query will be in the 15th argument.
+-                self.assertTrue(
+-                    postgres._run_psql.call_args[0][0][14].startswith("CREATE ROLE")
+-                )
+-
+-    def test_group_remove(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch("salt.modules.postgres.user_exists", Mock(return_value=True)):
+-                postgres.group_remove(
+-                    "testgroup",
+-                    user="testuser",
+-                    host="testhost",
+-                    port="testport",
+-                    maintenance_db="maint_db",
+-                    password="foo",
+-                    runas="foo",
+-                )
+-                postgres._run_psql.assert_called_once_with(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "maint_db",
+-                        "-c",
+-                        'DROP ROLE "testgroup"',
+-                    ],
+-                    host="testhost",
+-                    user="testuser",
+-                    password="foo",
+-                    runas="foo",
+-                    port="testport",
+-                )
+-
+-    def test_group_update(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.role_get",
+-                Mock(return_value={"superuser": False}),
+-            ):
+-                postgres.group_update(
+-                    "testgroup",
+-                    user='"testuser"',
+-                    host="testhost",
+-                    port="testport",
+-                    maintenance_db="maint_db",
+-                    password="foo",
+-                    createdb=False,
+-                    encrypted=False,
+-                    replication=False,
+-                    rolepassword="test_role_pass",
+-                    groups="testgroup",
+-                    runas="foo",
+-                )
+-                # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
+-                # The first 14 elements of this list are initial args used in all (or
+-                # virtually all) commands run through _run_psql(), so the actual SQL
+-                # query will be in the 15th argument.
+-                self.assertTrue(
+-                    re.match(
+-                        'ALTER.* "testgroup" .* UNENCRYPTED PASSWORD',
+-                        postgres._run_psql.call_args[0][0][14],
+-                    )
+-                )
+-
+-    def test_user_create(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch("salt.modules.postgres.user_exists", Mock(return_value=False)):
+-                postgres.user_create(
+-                    "testuser",
+-                    user="testuser",
+-                    host="testhost",
+-                    port="testport",
+-                    maintenance_db="maint_test",
+-                    password="test_pass",
+-                    login=True,
+-                    createdb=False,
+-                    createroles=False,
+-                    encrypted=False,
+-                    superuser=False,
+-                    replication=False,
+-                    rolepassword="test_role_pass",
+-                    valid_until="2042-07-01",
+-                    groups="test_groups",
+-                    runas="foo",
+-                )
+-                # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
+-                # The first 14 elements of this list are initial args used in all (or
+-                # virtually all) commands run through _run_psql(), so the actual SQL
+-                # query will be in the 15th argument.
+-                call = postgres._run_psql.call_args[0][0][14]
+-                self.assertTrue(re.match('CREATE ROLE "testuser"', call))
+-                for i in (
+-                    "INHERIT",
+-                    "NOCREATEDB",
+-                    "NOCREATEROLE",
+-                    "NOSUPERUSER",
+-                    "NOREPLICATION",
+-                    "LOGIN",
+-                    "UNENCRYPTED",
+-                    "PASSWORD",
+-                    "VALID UNTIL",
+-                ):
+-                    self.assertTrue(i in call, "{} not in {}".format(i, call))
+-
+-    def test_user_exists(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch("salt.modules.postgres.version", Mock(return_value="9.1")):
+-                with patch(
+-                    "salt.modules.postgres.psql_query",
+-                    Mock(
+-                        return_value=[
+-                            {
+-                                "name": "test_user",
+-                                "superuser": "t",
+-                                "inherits privileges": "t",
+-                                "can create roles": "t",
+-                                "can create databases": "t",
+-                                "can update system catalogs": "t",
+-                                "can login": "t",
+-                                "replication": None,
+-                                "password": "test_password",
+-                                "connections": "-1",
+-                                "groups": "",
+-                                "expiry time": "",
+-                                "defaults variables": None,
+-                            }
+-                        ]
+-                    ),
+-                ):
+-                    ret = postgres.user_exists(
+-                        "test_user",
+-                        user="test_user",
+-                        host="test_host",
+-                        port="test_port",
+-                        maintenance_db="maint_db",
+-                        password="test_password",
+-                        runas="foo",
+-                    )
+-                    self.assertTrue(ret)
+-
+-    def test_user_list(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch("salt.modules.postgres.version", Mock(return_value="9.1")):
+-                with patch(
+-                    "salt.modules.postgres.psql_query",
+-                    Mock(
+-                        return_value=[
+-                            {
+-                                "name": "test_user",
+-                                "superuser": "t",
+-                                "inherits privileges": "t",
+-                                "can create roles": "t",
+-                                "can create databases": "t",
+-                                "can update system catalogs": "t",
+-                                "can login": "t",
+-                                "replication": None,
+-                                "connections": "-1",
+-                                "groups": "",
+-                                "expiry time": "2017-08-16 08:57:46",
+-                                "defaults variables": None,
+-                            }
+-                        ]
+-                    ),
+-                ):
+-                    ret = postgres.user_list(
+-                        "test_user",
+-                        host="test_host",
+-                        port="test_port",
+-                        maintenance_db="maint_db",
+-                        password="test_password",
+-                        runas="foo",
+-                    )
+-
+-                    self.assertDictEqual(
+-                        ret,
+-                        {
+-                            "test_user": {
+-                                "superuser": True,
+-                                "defaults variables": None,
+-                                "can create databases": True,
+-                                "can create roles": True,
+-                                "connections": None,
+-                                "replication": None,
+-                                "expiry time": datetime.datetime(
+-                                    2017, 8, 16, 8, 57, 46
+-                                ),
+-                                "can login": True,
+-                                "can update system catalogs": True,
+-                                "groups": [],
+-                                "inherits privileges": True,
+-                            }
+-                        },
+-                    )
+-
+-    def test_user_remove(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch("salt.modules.postgres.version", Mock(return_value="9.1")):
+-                with patch(
+-                    "salt.modules.postgres.user_exists", Mock(return_value=True)
+-                ):
+-                    postgres.user_remove(
+-                        "testuser",
+-                        user="testuser",
+-                        host="testhost",
+-                        port="testport",
+-                        maintenance_db="maint_db",
+-                        password="testpassword",
+-                        runas="foo",
+-                    )
+-                    postgres._run_psql.assert_called_once_with(
+-                        [
+-                            "/usr/bin/pgsql",
+-                            "--no-align",
+-                            "--no-readline",
+-                            "--no-psqlrc",
+-                            "--no-password",
+-                            "--username",
+-                            "testuser",
+-                            "--host",
+-                            "testhost",
+-                            "--port",
+-                            "testport",
+-                            "--dbname",
+-                            "maint_db",
+-                            "-c",
+-                            'DROP ROLE "testuser"',
+-                        ],
+-                        host="testhost",
+-                        port="testport",
+-                        user="testuser",
+-                        password="testpassword",
+-                        runas="foo",
+-                    )
+-
+-    def test_user_update(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.role_get",
+-                Mock(return_value={"superuser": False}),
+-            ):
+-                postgres.user_update(
+-                    "test_username",
+-                    user="test_user",
+-                    host="test_host",
+-                    port="test_port",
+-                    maintenance_db="test_maint",
+-                    password="test_pass",
+-                    createdb=False,
+-                    createroles=False,
+-                    encrypted=False,
+-                    inherit=True,
+-                    login=True,
+-                    replication=False,
+-                    rolepassword="test_role_pass",
+-                    valid_until="2017-07-01",
+-                    groups="test_groups",
+-                    runas="foo",
+-                )
+-                # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
+-                # The first 14 elements of this list are initial args used in all (or
+-                # virtually all) commands run through _run_psql(), so the actual SQL
+-                # query will be in the 15th argument.
+-                self.assertTrue(
+-                    re.match(
+-                        'ALTER ROLE "test_username" WITH  INHERIT NOCREATEDB '
+-                        "NOCREATEROLE NOREPLICATION LOGIN "
+-                        "UNENCRYPTED PASSWORD ['\"]{0,5}test_role_pass['\"]{0,5} "
+-                        "VALID UNTIL '2017-07-01';"
+-                        ' GRANT "test_groups" TO "test_username"',
+-                        postgres._run_psql.call_args[0][0][14],
+-                    )
+-                )
+-
+-    def test_user_update2(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.role_get",
+-                Mock(return_value={"superuser": False}),
+-            ):
+-                postgres.user_update(
+-                    "test_username",
+-                    user="test_user",
+-                    host="test_host",
+-                    port="test_port",
+-                    maintenance_db="test_maint",
+-                    password="test_pass",
+-                    createdb=False,
+-                    createroles=True,
+-                    encrypted=False,
+-                    inherit=True,
+-                    login=True,
+-                    replication=False,
+-                    groups="test_groups",
+-                    runas="foo",
+-                )
+-                # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
+-                # The first 14 elements of this list are initial args used in all (or
+-                # virtually all) commands run through _run_psql(), so the actual SQL
+-                # query will be in the 15th argument.
+-                self.assertTrue(
+-                    re.match(
+-                        'ALTER ROLE "test_username" WITH  INHERIT NOCREATEDB '
+-                        "CREATEROLE NOREPLICATION LOGIN;"
+-                        ' GRANT "test_groups" TO "test_username"',
+-                        postgres._run_psql.call_args[0][0][14],
+-                    )
+-                )
+-
+-    def test_user_update3(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.role_get",
+-                Mock(return_value={"superuser": False}),
+-            ):
+-                postgres.user_update(
+-                    "test_username",
+-                    user="test_user",
+-                    host="test_host",
+-                    port="test_port",
+-                    maintenance_db="test_maint",
+-                    password="test_pass",
+-                    createdb=False,
+-                    createroles=True,
+-                    encrypted=False,
+-                    inherit=True,
+-                    login=True,
+-                    rolepassword=False,
+-                    replication=False,
+-                    groups="test_groups",
+-                    runas="foo",
+-                )
+-                # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
+-                # The first 14 elements of this list are initial args used in all (or
+-                # virtually all) commands run through _run_psql(), so the actual SQL
+-                # query will be in the 15th argument.
+-                self.assertTrue(
+-                    re.match(
+-                        'ALTER ROLE "test_username" WITH  INHERIT NOCREATEDB '
+-                        "CREATEROLE NOREPLICATION LOGIN NOPASSWORD;"
+-                        ' GRANT "test_groups" TO "test_username"',
+-                        postgres._run_psql.call_args[0][0][14],
+-                    )
+-                )
+-
+-    def test_user_update_encrypted_passwd(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.role_get",
+-                Mock(return_value={"superuser": False}),
+-            ):
+-                postgres.user_update(
+-                    "test_username",
+-                    user="test_user",
+-                    host="test_host",
+-                    port="test_port",
+-                    maintenance_db="test_maint",
+-                    password="test_pass",
+-                    createdb=False,
+-                    createroles=True,
+-                    encrypted=True,
+-                    inherit=True,
+-                    login=True,
+-                    rolepassword="foobar",
+-                    replication=False,
+-                    groups="test_groups",
+-                    runas="foo",
+-                )
+-                # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
+-                # The first 14 elements of this list are initial args used in all (or
+-                # virtually all) commands run through _run_psql(), so the actual SQL
+-                # query will be in the 15th argument.
+-                self.assertTrue(
+-                    re.match(
+-                        'ALTER ROLE "test_username" WITH  INHERIT NOCREATEDB '
+-                        "CREATEROLE NOREPLICATION LOGIN "
+-                        "ENCRYPTED PASSWORD "
+-                        "['\"]{0,5}md531c27e68d3771c392b52102c01be1da1['\"]{0,5}"
+-                        '; GRANT "test_groups" TO "test_username"',
+-                        postgres._run_psql.call_args[0][0][14],
+-                    )
+-                )
+-
+-    def test_version(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql",
+-            Mock(return_value={"retcode": 0, "stdout": "9.1.9"}),
+-        ):
+-            postgres.version(
+-                user="test_user",
+-                host="test_host",
+-                port="test_port",
+-                maintenance_db="test_maint",
+-                password="test_pass",
+-                runas="foo",
+-            )
+-            # postgres._run_psql.call_args[0][0] will contain the list of CLI args.
+-            # The first 14 elements of this list are initial args used in all (or
+-            # virtually all) commands run through _run_psql(), so the actual SQL
+-            # query will be in the 15th argument.
+-            self.assertTrue(
+-                re.match(
+-                    "SELECT setting FROM pg_catalog.pg_settings",
+-                    postgres._run_psql.call_args[0][0][14],
+-                )
+-            )
+-
+-    def test_installed_extensions(self):
+-        with patch(
+-            "salt.modules.postgres.psql_query",
+-            Mock(return_value=[{"extname": "foo", "extversion": "1"}]),
+-        ):
+-            exts = postgres.installed_extensions()
+-            self.assertEqual(exts, {"foo": {"extversion": "1", "extname": "foo"}})
+-
+-    def test_available_extensions(self):
+-        with patch(
+-            "salt.modules.postgres.psql_query",
+-            Mock(return_value=[{"name": "foo", "default_version": "1"}]),
+-        ):
+-            exts = postgres.available_extensions()
+-            self.assertEqual(exts, {"foo": {"default_version": "1", "name": "foo"}})
+-
+-    def test_drop_extension2(self):
+-        with patch(
+-            "salt.modules.postgres.installed_extensions", Mock(side_effect=[{}, {}])
+-        ):
+-            with patch(
+-                "salt.modules.postgres._psql_prepare_and_run", Mock(return_value=None)
+-            ):
+-                with patch(
+-                    "salt.modules.postgres.available_extensions",
+-                    Mock(return_value={"foo": {"default_version": "1", "name": "foo"}}),
+-                ):
+-                    self.assertEqual(postgres.drop_extension("foo"), True)
+-
+-    def test_drop_extension3(self):
+-        with patch(
+-            "salt.modules.postgres.installed_extensions",
+-            Mock(side_effect=[{"foo": {"extversion": "1", "extname": "foo"}}, {}]),
+-        ):
+-            with patch(
+-                "salt.modules.postgres._psql_prepare_and_run", Mock(return_value=None)
+-            ):
+-                with patch(
+-                    "salt.modules.postgres.available_extensions",
+-                    Mock(return_value={"foo": {"default_version": "1", "name": "foo"}}),
+-                ):
+-                    self.assertEqual(postgres.drop_extension("foo"), True)
+-
+-    def test_drop_extension1(self):
+-        with patch(
+-            "salt.modules.postgres.installed_extensions",
+-            Mock(
+-                side_effect=[
+-                    {"foo": {"extversion": "1", "extname": "foo"}},
+-                    {"foo": {"extversion": "1", "extname": "foo"}},
+-                ]
+-            ),
+-        ):
+-            with patch(
+-                "salt.modules.postgres._psql_prepare_and_run", Mock(return_value=None)
+-            ):
+-                with patch(
+-                    "salt.modules.postgres.available_extensions",
+-                    Mock(return_value={"foo": {"default_version": "1", "name": "foo"}}),
+-                ):
+-                    self.assertEqual(postgres.drop_extension("foo"), False)
+-
+-    def test_create_mtdata(self):
+-        with patch(
+-            "salt.modules.postgres.installed_extensions",
+-            Mock(
+-                return_value={
+-                    "foo": {
+-                        "extversion": "0.8",
+-                        "extrelocatable": "t",
+-                        "schema_name": "foo",
+-                        "extname": "foo",
+-                    }
+-                },
+-            ),
+-        ):
+-            with patch(
+-                "salt.modules.postgres.available_extensions",
+-                Mock(return_value={"foo": {"default_version": "1.4", "name": "foo"}}),
+-            ):
+-                ret = postgres.create_metadata("foo", schema="bar", ext_version="1.4")
+-                self.assertTrue(postgres._EXTENSION_INSTALLED in ret)
+-                self.assertTrue(postgres._EXTENSION_TO_UPGRADE in ret)
+-                self.assertTrue(postgres._EXTENSION_TO_MOVE in ret)
+-                ret = postgres.create_metadata("foo", schema="foo", ext_version="0.4")
+-                self.assertTrue(postgres._EXTENSION_INSTALLED in ret)
+-                self.assertFalse(postgres._EXTENSION_TO_UPGRADE in ret)
+-                self.assertFalse(postgres._EXTENSION_TO_MOVE in ret)
+-                ret = postgres.create_metadata("foo")
+-                self.assertTrue(postgres._EXTENSION_INSTALLED in ret)
+-                self.assertFalse(postgres._EXTENSION_TO_UPGRADE in ret)
+-                self.assertFalse(postgres._EXTENSION_TO_MOVE in ret)
+-                ret = postgres.create_metadata("foobar")
+-                self.assertTrue(postgres._EXTENSION_NOT_INSTALLED in ret)
+-                self.assertFalse(postgres._EXTENSION_INSTALLED in ret)
+-                self.assertFalse(postgres._EXTENSION_TO_UPGRADE in ret)
+-                self.assertFalse(postgres._EXTENSION_TO_MOVE in ret)
+-
+-    def test_create_extension_newerthan(self):
+-        """
+-        scenario of creating upgrading extensions with possible schema and
+-        version specifications
+-        """
+-        with patch(
+-            "salt.modules.postgres.create_metadata",
+-            Mock(
+-                side_effect=[
+-                    # create succeeded
+-                    [postgres._EXTENSION_NOT_INSTALLED],
+-                    [postgres._EXTENSION_INSTALLED],
+-                    [postgres._EXTENSION_NOT_INSTALLED],
+-                    [postgres._EXTENSION_INSTALLED],
+-                    # create failed
+-                    [postgres._EXTENSION_NOT_INSTALLED],
+-                    [postgres._EXTENSION_NOT_INSTALLED],
+-                    # move+upgrade succeeded
+-                    [
+-                        postgres._EXTENSION_TO_MOVE,
+-                        postgres._EXTENSION_TO_UPGRADE,
+-                        postgres._EXTENSION_INSTALLED,
+-                    ],
+-                    [postgres._EXTENSION_INSTALLED],
+-                    # move succeeded
+-                    [postgres._EXTENSION_TO_MOVE, postgres._EXTENSION_INSTALLED],
+-                    [postgres._EXTENSION_INSTALLED],
+-                    # upgrade succeeded
+-                    [postgres._EXTENSION_TO_UPGRADE, postgres._EXTENSION_INSTALLED],
+-                    [postgres._EXTENSION_INSTALLED],
+-                    # upgrade failed
+-                    [postgres._EXTENSION_TO_UPGRADE, postgres._EXTENSION_INSTALLED],
+-                    [postgres._EXTENSION_TO_UPGRADE, postgres._EXTENSION_INSTALLED],
+-                    # move failed
+-                    [postgres._EXTENSION_TO_MOVE, postgres._EXTENSION_INSTALLED],
+-                    [postgres._EXTENSION_TO_MOVE, postgres._EXTENSION_INSTALLED],
+-                ]
+-            ),
+-        ):
+-            with patch(
+-                "salt.modules.postgres._psql_prepare_and_run", Mock(return_value=None)
+-            ):
+-                with patch(
+-                    "salt.modules.postgres.available_extensions",
+-                    Mock(
+-                        return_value={"foo": {"default_version": "1.4", "name": "foo"}}
+-                    ),
+-                ):
+-                    self.assertTrue(postgres.create_extension("foo"))
+-                    self.assertTrue(
+-                        re.match(
+-                            'CREATE EXTENSION IF NOT EXISTS "foo" ;',
+-                            postgres._psql_prepare_and_run.call_args[0][0][1],
+-                        )
+-                    )
+-                    self.assertTrue(
+-                        postgres.create_extension(
+-                            "foo", schema="a", ext_version="b", from_version="c"
+-                        )
+-                    )
+-                    self.assertTrue(
+-                        re.match(
+-                            'CREATE EXTENSION IF NOT EXISTS "foo" '
+-                            'WITH SCHEMA "a" VERSION b FROM c ;',
+-                            postgres._psql_prepare_and_run.call_args[0][0][1],
+-                        )
+-                    )
+-                    self.assertFalse(postgres.create_extension("foo"))
+-                    ret = postgres.create_extension("foo", ext_version="a", schema="b")
+-                    self.assertTrue(ret)
+-                    self.assertTrue(
+-                        re.match(
+-                            'ALTER EXTENSION "foo" SET SCHEMA "b";'
+-                            ' ALTER EXTENSION "foo" UPDATE TO a;',
+-                            postgres._psql_prepare_and_run.call_args[0][0][1],
+-                        )
+-                    )
+-                    ret = postgres.create_extension("foo", ext_version="a", schema="b")
+-                    self.assertTrue(ret)
+-                    self.assertTrue(
+-                        re.match(
+-                            'ALTER EXTENSION "foo" SET SCHEMA "b";',
+-                            postgres._psql_prepare_and_run.call_args[0][0][1],
+-                        )
+-                    )
+-                    ret = postgres.create_extension("foo", ext_version="a", schema="b")
+-                    self.assertTrue(ret)
+-                    self.assertTrue(
+-                        re.match(
+-                            'ALTER EXTENSION "foo" UPDATE TO a;',
+-                            postgres._psql_prepare_and_run.call_args[0][0][1],
+-                        )
+-                    )
+-                    self.assertFalse(
+-                        postgres.create_extension("foo", ext_version="a", schema="b")
+-                    )
+-                    self.assertFalse(
+-                        postgres.create_extension("foo", ext_version="a", schema="b")
+-                    )
+-
+-    def test_encrypt_passwords(self):
+-        self.assertEqual(postgres._maybe_encrypt_password("foo", "bar", False), "bar")
+-        self.assertEqual(
+-            postgres._maybe_encrypt_password("foo", "bar", True),
+-            "md596948aad3fcae80c08a35c9b5958cd89",
+-        )
+-
+-    def test_schema_list(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql",
+-            Mock(return_value={"retcode": 0, "stdout": test_list_schema_csv}),
+-        ):
+-            ret = postgres.schema_list(
+-                "maint_db",
+-                db_user="testuser",
+-                db_host="testhost",
+-                db_port="testport",
+-                db_password="foo",
+-            )
+-            self.assertDictEqual(
+-                ret,
+-                {
+-                    "public": {
+-                        "acl": "{postgres=UC/postgres,=UC/postgres}",
+-                        "owner": "postgres",
+-                    },
+-                    "pg_toast": {"acl": "", "owner": "postgres"},
+-                },
+-            )
+-
+-    def test_schema_exists(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.psql_query",
+-                Mock(
+-                    return_value=[
+-                        {
+-                            "name": "public",
+-                            "acl": "{postgres=UC/postgres,=UC/postgres}",
+-                            "owner": "postgres",
+-                        }
+-                    ]
+-                ),
+-            ):
+-                ret = postgres.schema_exists("template1", "public")
+-                self.assertTrue(ret)
+-
+-    def test_schema_get(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.psql_query",
+-                Mock(
+-                    return_value=[
+-                        {
+-                            "name": "public",
+-                            "acl": "{postgres=UC/postgres,=UC/postgres}",
+-                            "owner": "postgres",
+-                        }
+-                    ]
+-                ),
+-            ):
+-                ret = postgres.schema_get("template1", "public")
+-                self.assertTrue(ret)
+-
+-    def test_schema_get_again(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.psql_query",
+-                Mock(
+-                    return_value=[
+-                        {
+-                            "name": "public",
+-                            "acl": "{postgres=UC/postgres,=UC/postgres}",
+-                            "owner": "postgres",
+-                        }
+-                    ]
+-                ),
+-            ):
+-                ret = postgres.schema_get("template1", "pg_toast")
+-                self.assertFalse(ret)
+-
+-    def test_schema_create(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch("salt.modules.postgres.schema_exists", Mock(return_value=False)):
+-                postgres.schema_create(
+-                    "maint_db",
+-                    "testschema",
+-                    user="user",
+-                    db_host="testhost",
+-                    db_port="testport",
+-                    db_user="testuser",
+-                    db_password="testpassword",
+-                )
+-                postgres._run_psql.assert_called_once_with(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "maint_db",
+-                        "-c",
+-                        'CREATE SCHEMA "testschema"',
+-                    ],
+-                    host="testhost",
+-                    port="testport",
+-                    password="testpassword",
+-                    user="testuser",
+-                    runas="user",
+-                )
+-
+-    def test_schema_create2(self):
+-        with patch("salt.modules.postgres.schema_exists", Mock(return_value=True)):
+-            ret = postgres.schema_create(
+-                "test_db",
+-                "test_schema",
+-                user="user",
+-                db_host="test_host",
+-                db_port="test_port",
+-                db_user="test_user",
+-                db_password="test_password",
+-            )
+-            self.assertFalse(ret)
+-
+-    def test_schema_remove(self):
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch("salt.modules.postgres.schema_exists", Mock(return_value=True)):
+-                postgres.schema_remove(
+-                    "maint_db",
+-                    "testschema",
+-                    user="user",
+-                    db_host="testhost",
+-                    db_port="testport",
+-                    db_user="testuser",
+-                    db_password="testpassword",
+-                )
+-                postgres._run_psql.assert_called_once_with(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "maint_db",
+-                        "-c",
+-                        'DROP SCHEMA "testschema"',
+-                    ],
+-                    host="testhost",
+-                    port="testport",
+-                    password="testpassword",
+-                    user="testuser",
+-                    runas="user",
+-                )
+-
+-    def test_schema_remove2(self):
+-        with patch("salt.modules.postgres.schema_exists", Mock(return_value=False)):
+-            ret = postgres.schema_remove(
+-                "test_db",
+-                "test_schema",
+-                user="user",
+-                db_host="test_host",
+-                db_port="test_port",
+-                db_user="test_user",
+-                db_password="test_password",
+-            )
+-            self.assertFalse(ret)
+-
+-    def test_language_list(self):
+-        """
+-        Test language listing
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_psql",
+-            Mock(return_value={"retcode": 0, "stdout": test_list_language_csv}),
+-        ):
+-            ret = postgres.language_list(
+-                "testdb",
+-                user="testuser",
+-                host="testhost",
+-                port="testport",
+-                password="foo",
+-            )
+-            self.assertDictEqual(
+-                ret,
+-                {"c": "c", "internal": "internal", "plpgsql": "plpgsql", "sql": "sql"},
+-            )
+-
+-    def test_language_exists(self):
+-        """
+-        Test language existence check
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.psql_query",
+-                Mock(
+-                    return_value=[
+-                        {"Name": "internal"},
+-                        {"Name": "c"},
+-                        {"Name": "sql"},
+-                        {"Name": "plpgsql"},
+-                    ]
+-                ),
+-            ):
+-                with patch(
+-                    "salt.modules.postgres.language_exists", Mock(return_value=True)
+-                ):
+-                    ret = postgres.language_exists("sql", "testdb")
+-                    self.assertTrue(ret)
+-
+-    def test_language_create(self):
+-        """
+-        Test language creation - does not exist in db
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.language_exists", Mock(return_value=False)
+-            ):
+-                postgres.language_create(
+-                    "plpythonu",
+-                    "testdb",
+-                    runas="user",
+-                    host="testhost",
+-                    port="testport",
+-                    user="testuser",
+-                    password="testpassword",
+-                )
+-                postgres._run_psql.assert_called_once_with(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "testdb",
+-                        "-c",
+-                        "CREATE LANGUAGE plpythonu",
+-                    ],
+-                    host="testhost",
+-                    port="testport",
+-                    password="testpassword",
+-                    user="testuser",
+-                    runas="user",
+-                )
+-
+-    def test_language_create_exists(self):
+-        """
+-        Test language creation - already exists in db
+-        """
+-        with patch("salt.modules.postgres.language_exists", Mock(return_value=True)):
+-            ret = postgres.language_create(
+-                "plpythonu",
+-                "testdb",
+-                runas="user",
+-                host="testhost",
+-                port="testport",
+-                user="testuser",
+-                password="testpassword",
+-            )
+-            self.assertFalse(ret)
+-
+-    def test_language_remove(self):
+-        """
+-        Test language removal - exists in db
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.language_exists", Mock(return_value=True)
+-            ):
+-                postgres.language_remove(
+-                    "plpgsql",
+-                    "testdb",
+-                    runas="user",
+-                    host="testhost",
+-                    port="testport",
+-                    user="testuser",
+-                    password="testpassword",
+-                )
+-                postgres._run_psql.assert_called_once_with(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "testdb",
+-                        "-c",
+-                        "DROP LANGUAGE plpgsql",
+-                    ],
+-                    host="testhost",
+-                    port="testport",
+-                    password="testpassword",
+-                    user="testuser",
+-                    runas="user",
+-                )
+-
+-    def test_language_remove_non_exist(self):
+-        """
+-        Test language removal - does not exist in db
+-        """
+-        with patch("salt.modules.postgres.language_exists", Mock(return_value=False)):
+-            ret = postgres.language_remove(
+-                "plpgsql",
+-                "testdb",
+-                runas="user",
+-                host="testhost",
+-                port="testport",
+-                user="testuser",
+-                password="testpassword",
+-            )
+-            self.assertFalse(ret)
+-
+-    def test_privileges_list_table(self):
+-        """
+-        Test privilege listing on a table
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_psql",
+-            Mock(return_value={"retcode": 0, "stdout": test_privileges_list_table_csv}),
+-        ):
+-            ret = postgres.privileges_list(
+-                "awl",
+-                "table",
+-                maintenance_db="db_name",
+-                runas="user",
+-                host="testhost",
+-                port="testport",
+-                user="testuser",
+-                password="testpassword",
+-            )
+-            expected = {
+-                "bayestest": {
+-                    "INSERT": False,
+-                    "UPDATE": False,
+-                    "SELECT": False,
+-                    "DELETE": False,
+-                },
+-                "baruwa": {
+-                    "INSERT": True,
+-                    "TRUNCATE": True,
+-                    "UPDATE": True,
+-                    "TRIGGER": True,
+-                    "REFERENCES": True,
+-                    "SELECT": True,
+-                    "DELETE": True,
+-                },
+-                "baruwatest": {
+-                    "INSERT": False,
+-                    "TRUNCATE": False,
+-                    "UPDATE": False,
+-                    "TRIGGER": False,
+-                    "REFERENCES": False,
+-                    "SELECT": False,
+-                    "DELETE": False,
+-                },
+-            }
+-
+-            self.assertDictEqual(ret, expected)
+-
+-            query = (
+-                "COPY (SELECT relacl AS name FROM pg_catalog.pg_class c "
+-                "JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+-                "WHERE nspname = 'public' AND relname = 'awl' AND relkind in ('r', 'v') "
+-                "ORDER BY relname) TO STDOUT WITH CSV HEADER"
+-            )
+-
+-            postgres._run_psql.assert_called_once_with(
+-                [
+-                    "/usr/bin/pgsql",
+-                    "--no-align",
+-                    "--no-readline",
+-                    "--no-psqlrc",
+-                    "--no-password",
+-                    "--username",
+-                    "testuser",
+-                    "--host",
+-                    "testhost",
+-                    "--port",
+-                    "testport",
+-                    "--dbname",
+-                    "db_name",
+-                    "-v",
+-                    "datestyle=ISO,MDY",
+-                    "-c",
+-                    query,
+-                ],
+-                host="testhost",
+-                port="testport",
+-                password="testpassword",
+-                user="testuser",
+-                runas="user",
+-            )
+-
+-    def test_privileges_list_group(self):
+-        """
+-        Test privilege listing on a group
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_psql",
+-            Mock(return_value={"retcode": 0, "stdout": test_privileges_list_group_csv}),
+-        ):
+-            ret = postgres.privileges_list(
+-                "admin",
+-                "group",
+-                maintenance_db="db_name",
+-                runas="user",
+-                host="testhost",
+-                port="testport",
+-                user="testuser",
+-                password="testpassword",
+-            )
+-            expected = {
+-                "baruwa": False,
+-                "baruwatest": False,
+-                "baruwatest2": True,
+-            }
+-
+-            self.assertDictEqual(ret, expected)
+-
+-            query = (
+-                "COPY (SELECT rolname, admin_option "
+-                "FROM pg_catalog.pg_auth_members m JOIN pg_catalog.pg_roles r "
+-                "ON m.member=r.oid WHERE m.roleid IN (SELECT oid FROM "
+-                "pg_catalog.pg_roles WHERE rolname='admin') ORDER BY rolname) "
+-                "TO STDOUT WITH CSV HEADER"
+-            )
+-
+-            postgres._run_psql.assert_called_once_with(
+-                [
+-                    "/usr/bin/pgsql",
+-                    "--no-align",
+-                    "--no-readline",
+-                    "--no-psqlrc",
+-                    "--no-password",
+-                    "--username",
+-                    "testuser",
+-                    "--host",
+-                    "testhost",
+-                    "--port",
+-                    "testport",
+-                    "--dbname",
+-                    "db_name",
+-                    "-v",
+-                    "datestyle=ISO,MDY",
+-                    "-c",
+-                    query,
+-                ],
+-                host="testhost",
+-                port="testport",
+-                password="testpassword",
+-                user="testuser",
+-                runas="user",
+-            )
+-
+-    def test_has_privileges_on_table(self):
+-        """
+-        Test privilege checks on table
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_psql",
+-            Mock(return_value={"retcode": 0, "stdout": test_privileges_list_table_csv}),
+-        ):
+-            ret = postgres.has_privileges(
+-                "baruwa",
+-                "awl",
+-                "table",
+-                "SELECT,INSERT",
+-                grant_option=True,
+-                maintenance_db="db_name",
+-                runas="user",
+-                host="testhost",
+-                port="testport",
+-                user="testuser",
+-                password="testpassword",
+-            )
+-
+-            self.assertTrue(ret)
+-
+-            ret = postgres.has_privileges(
+-                "baruwa",
+-                "awl",
+-                "table",
+-                "ALL",
+-                grant_option=True,
+-                maintenance_db="db_name",
+-                runas="user",
+-                host="testhost",
+-                port="testport",
+-                user="testuser",
+-                password="testpassword",
+-            )
+-
+-            self.assertTrue(ret)
+-
+-            ret = postgres.has_privileges(
+-                "baruwa",
+-                "awl",
+-                "table",
+-                "ALL",
+-                grant_option=False,
+-                maintenance_db="db_name",
+-                runas="user",
+-                host="testhost",
+-                port="testport",
+-                user="testuser",
+-                password="testpassword",
+-            )
+-
+-            self.assertTrue(ret)
+-
+-            ret = postgres.has_privileges(
+-                "bayestest",
+-                "awl",
+-                "table",
+-                "SELECT,INSERT,TRUNCATE",
+-                maintenance_db="db_name",
+-                runas="user",
+-                host="testhost",
+-                port="testport",
+-                user="testuser",
+-                password="testpassword",
+-            )
+-
+-            self.assertFalse(ret)
+-
+-            ret = postgres.has_privileges(
+-                "bayestest",
+-                "awl",
+-                "table",
+-                "SELECT,INSERT",
+-                maintenance_db="db_name",
+-                runas="user",
+-                host="testhost",
+-                port="testport",
+-                user="testuser",
+-                password="testpassword",
+-            )
+-
+-            self.assertTrue(ret)
+-
+-    def test_has_privileges_on_group(self):
+-        """
+-        Test privilege checks on group
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_psql",
+-            Mock(return_value={"retcode": 0, "stdout": test_privileges_list_group_csv}),
+-        ):
+-            ret = postgres.has_privileges(
+-                "baruwa",
+-                "admin",
+-                "group",
+-                maintenance_db="db_name",
+-                runas="user",
+-                host="testhost",
+-                port="testport",
+-                user="testuser",
+-                password="testpassword",
+-            )
+-
+-            self.assertTrue(ret)
+-
+-            ret = postgres.has_privileges(
+-                "baruwa",
+-                "admin",
+-                "group",
+-                grant_option=True,
+-                maintenance_db="db_name",
+-                runas="user",
+-                host="testhost",
+-                port="testport",
+-                user="testuser",
+-                password="testpassword",
+-            )
+-
+-            self.assertFalse(ret)
+-
+-            ret = postgres.has_privileges(
+-                "tony",
+-                "admin",
+-                "group",
+-                maintenance_db="db_name",
+-                runas="user",
+-                host="testhost",
+-                port="testport",
+-                user="testuser",
+-                password="testpassword",
+-            )
+-
+-            self.assertFalse(ret)
+-
+-    def test_privileges_grant_table(self):
+-        """
+-        Test granting privileges on table
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.has_privileges", Mock(return_value=False)
+-            ):
+-                ret = postgres.privileges_grant(
+-                    "baruwa",
+-                    "awl",
+-                    "table",
+-                    "ALL",
+-                    grant_option=True,
+-                    maintenance_db="db_name",
+-                    runas="user",
+-                    host="testhost",
+-                    port="testport",
+-                    user="testuser",
+-                    password="testpassword",
+-                )
+-
+-                query = 'GRANT ALL ON TABLE public."awl" TO "baruwa" WITH GRANT OPTION'
+-
+-                postgres._run_psql.assert_called_once_with(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "db_name",
+-                        "-c",
+-                        query,
+-                    ],
+-                    host="testhost",
+-                    port="testport",
+-                    password="testpassword",
+-                    user="testuser",
+-                    runas="user",
+-                )
+-
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.has_privileges", Mock(return_value=False)
+-            ):
+-                ret = postgres.privileges_grant(
+-                    "baruwa",
+-                    "awl",
+-                    "table",
+-                    "ALL",
+-                    maintenance_db="db_name",
+-                    runas="user",
+-                    host="testhost",
+-                    port="testport",
+-                    user="testuser",
+-                    password="testpassword",
+-                )
+-
+-                query = 'GRANT ALL ON TABLE public."awl" TO "baruwa"'
+-
+-                postgres._run_psql.assert_called_once_with(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "db_name",
+-                        "-c",
+-                        query,
+-                    ],
+-                    host="testhost",
+-                    port="testport",
+-                    password="testpassword",
+-                    user="testuser",
+-                    runas="user",
+-                )
+-
+-        # Test grant on all tables
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.has_privileges", Mock(return_value=False)
+-            ):
+-                ret = postgres.privileges_grant(
+-                    "baruwa",
+-                    "ALL",
+-                    "table",
+-                    "SELECT",
+-                    maintenance_db="db_name",
+-                    runas="user",
+-                    host="testhost",
+-                    port="testport",
+-                    user="testuser",
+-                    password="testpassword",
+-                )
+-
+-                query = 'GRANT SELECT ON ALL TABLES IN SCHEMA public TO "baruwa"'
+-
+-                postgres._run_psql.assert_called_once_with(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "db_name",
+-                        "-c",
+-                        query,
+-                    ],
+-                    host="testhost",
+-                    port="testport",
+-                    password="testpassword",
+-                    user="testuser",
+-                    runas="user",
+-                )
+-
+-    def test_privileges_grant_group(self):
+-        """
+-        Test granting privileges on group
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.has_privileges", Mock(return_value=False)
+-            ):
+-                ret = postgres.privileges_grant(
+-                    "baruwa",
+-                    "admins",
+-                    "group",
+-                    grant_option=True,
+-                    maintenance_db="db_name",
+-                    runas="user",
+-                    host="testhost",
+-                    port="testport",
+-                    user="testuser",
+-                    password="testpassword",
+-                )
+-
+-                query = 'GRANT admins TO "baruwa" WITH ADMIN OPTION'
+-
+-                postgres._run_psql.assert_called_once_with(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "db_name",
+-                        "-c",
+-                        query,
+-                    ],
+-                    host="testhost",
+-                    port="testport",
+-                    password="testpassword",
+-                    user="testuser",
+-                    runas="user",
+-                )
+-
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.has_privileges", Mock(return_value=False)
+-            ):
+-                ret = postgres.privileges_grant(
+-                    "baruwa",
+-                    "admins",
+-                    "group",
+-                    maintenance_db="db_name",
+-                    runas="user",
+-                    host="testhost",
+-                    port="testport",
+-                    user="testuser",
+-                    password="testpassword",
+-                )
+-
+-                query = 'GRANT admins TO "baruwa"'
+-
+-                postgres._run_psql.assert_called_once_with(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "db_name",
+-                        "-c",
+-                        query,
+-                    ],
+-                    host="testhost",
+-                    port="testport",
+-                    password="testpassword",
+-                    user="testuser",
+-                    runas="user",
+-                )
+-
+-    def test_privileges_revoke_table(self):
+-        """
+-        Test revoking privileges on table
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch("salt.modules.postgres.has_privileges", Mock(return_value=True)):
+-                ret = postgres.privileges_revoke(
+-                    "baruwa",
+-                    "awl",
+-                    "table",
+-                    "ALL",
+-                    maintenance_db="db_name",
+-                    runas="user",
+-                    host="testhost",
+-                    port="testport",
+-                    user="testuser",
+-                    password="testpassword",
+-                )
+-
+-                query = "REVOKE ALL ON TABLE public.awl FROM baruwa"
+-
+-                postgres._run_psql.assert_called_once_with(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "db_name",
+-                        "-c",
+-                        query,
+-                    ],
+-                    host="testhost",
+-                    port="testport",
+-                    password="testpassword",
+-                    user="testuser",
+-                    runas="user",
+-                )
+-
+-    def test_privileges_revoke_group(self):
+-        """
+-        Test revoking privileges on group
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_psql", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch("salt.modules.postgres.has_privileges", Mock(return_value=True)):
+-                ret = postgres.privileges_revoke(
+-                    "baruwa",
+-                    "admins",
+-                    "group",
+-                    maintenance_db="db_name",
+-                    runas="user",
+-                    host="testhost",
+-                    port="testport",
+-                    user="testuser",
+-                    password="testpassword",
+-                )
+-
+-                query = "REVOKE admins FROM baruwa"
+-
+-                postgres._run_psql.assert_called_once_with(
+-                    [
+-                        "/usr/bin/pgsql",
+-                        "--no-align",
+-                        "--no-readline",
+-                        "--no-psqlrc",
+-                        "--no-password",
+-                        "--username",
+-                        "testuser",
+-                        "--host",
+-                        "testhost",
+-                        "--port",
+-                        "testport",
+-                        "--dbname",
+-                        "db_name",
+-                        "-c",
+-                        query,
+-                    ],
+-                    host="testhost",
+-                    port="testport",
+-                    password="testpassword",
+-                    user="testuser",
+-                    runas="user",
+-                )
+-
+-    def test_datadir_init(self):
+-        """
+-        Test Initializing a postgres data directory
+-        """
+-        with patch(
+-            "salt.modules.postgres._run_initdb", Mock(return_value={"retcode": 0})
+-        ):
+-            with patch(
+-                "salt.modules.postgres.datadir_exists", Mock(return_value=False)
+-            ):
+-                name = "/var/lib/pgsql/data"
+-                ret = postgres.datadir_init(
+-                    name, user="postgres", password="test", runas="postgres"
+-                )
+-                postgres._run_initdb.assert_called_once_with(
+-                    name,
+-                    auth="password",
+-                    encoding="UTF8",
+-                    locale=None,
+-                    password="test",
+-                    runas="postgres",
+-                    checksums=False,
+-                    waldir=None,
+-                    user="postgres",
+-                )
+-                self.assertTrue(ret)
+-
+-    def test_datadir_exists(self):
+-        """
+-        Test Checks if postgres data directory has been initialized
+-        """
+-        with patch("os.path.isfile", Mock(return_value=True)):
+-            name = "/var/lib/pgsql/data"
+-            ret = postgres.datadir_exists(name)
+-            self.assertTrue(ret)
+-
+-    def test_pg_is_older_ext_ver(self):
+-        """
+-        Test Checks if postgres extension version string is older
+-        """
+-        self.assertTrue(postgres._pg_is_older_ext_ver("8.5", "9.5"))
+-        self.assertTrue(postgres._pg_is_older_ext_ver("8.5", "8.6"))
+-        self.assertTrue(postgres._pg_is_older_ext_ver("8.5.2", "8.5.3"))
+-        self.assertFalse(postgres._pg_is_older_ext_ver("9.5", "8.5"))
+-        self.assertTrue(postgres._pg_is_older_ext_ver("9.5", "9.6"))
+-        self.assertTrue(postgres._pg_is_older_ext_ver("9.5.0", "9.5.1"))
+-        self.assertTrue(postgres._pg_is_older_ext_ver("9.5", "9.5.1"))
+-        self.assertFalse(postgres._pg_is_older_ext_ver("9.5.1", "9.5"))
+-        self.assertFalse(postgres._pg_is_older_ext_ver("9.5b", "9.5a"))
+-        self.assertTrue(postgres._pg_is_older_ext_ver("10a", "10b"))
+-        self.assertTrue(postgres._pg_is_older_ext_ver("1.2.3.4", "1.2.3.5"))
+-        self.assertTrue(postgres._pg_is_older_ext_ver("10dev", "10next"))
+-        self.assertFalse(postgres._pg_is_older_ext_ver("10next", "10dev"))
+-- 
+2.52.0
+

--- a/salt/extend-fails-to-warnings-until-2027-742.patch
+++ b/salt/extend-fails-to-warnings-until-2027-742.patch
@@ -1,0 +1,164 @@
+From 85d5cab70fc36994427fb4d4ca483b09f55d28f7 Mon Sep 17 00:00:00 2001
+From: Marek Czernek <marek.czernek@suse.com>
+Date: Thu, 8 Jan 2026 09:17:14 +0100
+Subject: [PATCH] Extend fails to warnings until 2027 (#742)
+
+---
+ salt/_logging/handlers.py          | 6 +++---
+ salt/log/__init__.py               | 2 +-
+ salt/log/handlers/__init__.py      | 2 +-
+ salt/log/mixins.py                 | 2 +-
+ salt/log/setup.py                  | 4 ++--
+ salt/modules/aptpkg.py             | 2 +-
+ salt/modules/cassandra_mod.py      | 2 +-
+ salt/returners/cassandra_return.py | 2 +-
+ salt/returners/django_return.py    | 2 +-
+ 9 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/salt/_logging/handlers.py b/salt/_logging/handlers.py
+index d8bc68a49db..6b1521d7915 100644
+--- a/salt/_logging/handlers.py
++++ b/salt/_logging/handlers.py
+@@ -36,7 +36,7 @@ class TemporaryLoggingHandler(logging.NullHandler):
+ 
+     def __init__(self, level=logging.NOTSET, max_queue_size=10000):
+         warn_until_date(
+-            "20260101",
++            "20270101",
+             "Please stop using '{name}.TemporaryLoggingHandler'. "
+             "'{name}.TemporaryLoggingHandler' will go away after "
+             "{{date}}.".format(name=__name__),
+@@ -229,7 +229,7 @@ if sys.version_info < (3, 7):
+         def __init__(self, queue):  # pylint: disable=useless-super-delegation
+             super().__init__(queue)
+             warn_until_date(
+-                "20260101",
++                "20270101",
+                 "Please stop using '{name}.QueueHandler' and instead "
+                 "use 'logging.handlers.QueueHandler'. "
+                 "'{name}.QueueHandler' will go away after "
+@@ -287,7 +287,7 @@ else:
+         def __init__(self, queue):  # pylint: disable=useless-super-delegation
+             super().__init__(queue)
+             warn_until_date(
+-                "20260101",
++                "20270101",
+                 "Please stop using '{name}.QueueHandler' and instead "
+                 "use 'logging.handlers.QueueHandler'. "
+                 "'{name}.QueueHandler' will go away after "
+diff --git a/salt/log/__init__.py b/salt/log/__init__.py
+index 69bfa8ed15b..392fd1561dd 100644
+--- a/salt/log/__init__.py
++++ b/salt/log/__init__.py
+@@ -24,7 +24,7 @@ from salt.log.setup import (
+ from salt.utils.versions import warn_until_date
+ 
+ warn_until_date(
+-    "20260101",
++    "20270101",
+     "Please stop using '{name}' and instead use 'salt._logging'. "
+     "'{name}' will go away after {{date}}.".format(name=__name__),
+     stacklevel=3,
+diff --git a/salt/log/handlers/__init__.py b/salt/log/handlers/__init__.py
+index 55cf10cdb78..f6f8102fd65 100644
+--- a/salt/log/handlers/__init__.py
++++ b/salt/log/handlers/__init__.py
+@@ -12,7 +12,7 @@ from salt._logging.handlers import (
+ from salt.utils.versions import warn_until_date
+ 
+ warn_until_date(
+-    "20260101",
++    "20270101",
+     "Please stop using '{name}' and instead use 'salt._logging.handlers'. "
+     "'{name}' will go away after {{date}}.".format(name=__name__),
+ )
+diff --git a/salt/log/mixins.py b/salt/log/mixins.py
+index 65f5ed7f78a..4564ac225c3 100644
+--- a/salt/log/mixins.py
++++ b/salt/log/mixins.py
+@@ -11,7 +11,7 @@ from salt.utils.versions import warn_until_date
+ # pylint: enable=unused-import
+ 
+ warn_until_date(
+-    "20260101",
++    "20270101",
+     "Please stop using '{name}' and instead use 'salt._logging.mixins'. "
+     "'{name}' will go away after {{date}}.".format(name=__name__),
+ )
+diff --git a/salt/log/setup.py b/salt/log/setup.py
+index f4c80b0f280..5435d6de88f 100644
+--- a/salt/log/setup.py
++++ b/salt/log/setup.py
+@@ -21,7 +21,7 @@ from salt._logging.impl import set_log_record_factory as setLogRecordFactory
+ from salt.utils.versions import warn_until_date
+ 
+ warn_until_date(
+-    "20260101",
++    "20270101",
+     "Please stop using '{name}' and instead use 'salt._logging'. "
+     "'{name}' will go away after {{date}}. Do note however that "
+     "'salt._logging' is now considered a non public implementation "
+@@ -34,7 +34,7 @@ def _deprecated_warning(func):
+     @wraps(func)
+     def wrapper(*args, **kwargs):
+         warn_until_date(
+-            "20260101",
++            "20270101",
+             "Please stop using 'salt.log.setup.{name}()' as it no longer does anything and "
+             "will go away after {{date}}.".format(name=func.__qualname__),
+             stacklevel=4,
+diff --git a/salt/modules/aptpkg.py b/salt/modules/aptpkg.py
+index 8244c639e85..f7884d9ccde 100644
+--- a/salt/modules/aptpkg.py
++++ b/salt/modules/aptpkg.py
+@@ -3215,7 +3215,7 @@ def expand_repo_def(**kwargs):
+         NOT USABLE IN THE CLI
+     """
+     warn_until_date(
+-        "20260101",
++        "20270101",
+         "The pkg.expand_repo_def function is deprecated and set for removal "
+         "after {date}. This is only unsed internally by the apt pkg state "
+         "module. If that's not the case, please file an new issue requesting "
+diff --git a/salt/modules/cassandra_mod.py b/salt/modules/cassandra_mod.py
+index db9c8821920..660a1ff70dd 100644
+--- a/salt/modules/cassandra_mod.py
++++ b/salt/modules/cassandra_mod.py
+@@ -45,7 +45,7 @@ def __virtual__():
+         )
+ 
+     warn_until_date(
+-        "20260101",
++        "20270101",
+         "The cassandra returner is broken and deprecated, and will be removed"
+         " after {date}. Use the cassandra_cql returner instead",
+     )
+diff --git a/salt/returners/cassandra_return.py b/salt/returners/cassandra_return.py
+index 5fcc00ee8ce..00c6748eaeb 100644
+--- a/salt/returners/cassandra_return.py
++++ b/salt/returners/cassandra_return.py
+@@ -53,7 +53,7 @@ def __virtual__():
+     if not HAS_PYCASSA:
+         return False, "Could not import cassandra returner; pycassa is not installed."
+     warn_until_date(
+-        "20260101",
++        "20270101",
+         "The cassandra returner is broken and deprecated, and will be removed"
+         " after {date}. Use the cassandra_cql returner instead",
+     )
+diff --git a/salt/returners/django_return.py b/salt/returners/django_return.py
+index 474653f3831..46f5c8791e8 100644
+--- a/salt/returners/django_return.py
++++ b/salt/returners/django_return.py
+@@ -57,7 +57,7 @@ __virtualname__ = "django"
+ 
+ def __virtual__():
+     warn_until_date(
+-        "20260101",
++        "20270101",
+         "The django returner is broken and deprecated, and will be removed"
+         " after {date}.",
+     )
+-- 
+2.52.0
+

--- a/salt/fix-tornado-s-httputil_test-syntax-for-python-3.6.patch
+++ b/salt/fix-tornado-s-httputil_test-syntax-for-python-3.6.patch
@@ -1,0 +1,25 @@
+From f5ac4c6f38cf9db39a8fbd31a101f155de40f37c Mon Sep 17 00:00:00 2001
+From: Alexander Graul <agraul@suse.com>
+Date: Fri, 16 Jan 2026 17:34:18 +0100
+Subject: [PATCH] Fix tornado's httputil_test syntax for Python 3.6
+
+---
+ salt/ext/tornado/test/httputil_test.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/salt/ext/tornado/test/httputil_test.py b/salt/ext/tornado/test/httputil_test.py
+index bdbfaa2b6a..cacd31aa05 100644
+--- a/salt/ext/tornado/test/httputil_test.py
++++ b/salt/ext/tornado/test/httputil_test.py
+@@ -266,7 +266,7 @@ Foo
+         d1 = f(1_000)
+         d2 = f(10_000)
+         if d2 / d1 > 20:
+-            self.fail(f"Disposition param parsing is not linear: {d1=} vs {d2=}")
++            self.fail(f"Disposition param parsing is not linear: d1={d1} vs d2={d2}")
+ 
+ 
+ class HTTPHeadersTest(unittest.TestCase):
+-- 
+2.52.0
+

--- a/salt/fixes-for-security-issues-cve-2025-13836-cve-2025-67.patch
+++ b/salt/fixes-for-security-issues-cve-2025-13836-cve-2025-67.patch
@@ -1,0 +1,232 @@
+From 324c7740438fd0bbcde1e0b6be70c92007c022ac Mon Sep 17 00:00:00 2001
+From: Victor Zhestkov <vzhestkov@suse.com>
+Date: Wed, 14 Jan 2026 14:08:48 +0100
+Subject: [PATCH] Fixes for security issues (CVE-2025-13836,
+ CVE-2025-67725, CVE-2025-67726) (#744)
+
+* Fixes for security issues (CVE-2025-67725)
+
+httputil: Fix quadratic performance of repeated header lines
+
+Previouisly, when many header lines with the same name were found
+in an HTTP request or response, repeated string concatenation would
+result in quadratic performance. This change does the concatenation
+lazily (with a cache) so that repeated headers can be processed
+efficiently.
+
+Security: The previous behavior allowed a denial of service attack
+via a maliciously crafted HTTP message, but only if the
+max_header_size was increased from its default of 64kB.
+
+* Patch tornado for (BDSA-2025-60811, CVE-2025-67726)
+
+httputil: Fix quadratic behavior in _parseparam
+
+Prior to this change, _parseparam had O(n^2) behavior when parsing
+certain inputs, which could be a DoS vector. This change adapts
+logic from the equivalent function in the python standard library
+in https://github.com/python/cpython/pull/136072/files
+
+* Set a safe limit to http.client response read (CVE-2025-13836)
+
+https://github.com/saltstack/salt/pull/68611
+
+* Remove duplicated test
+
+---------
+
+Co-authored-by: Twangboy <shane.d.lee@gmail.com>
+Co-authored-by: Marek Czernek <marek.czernek@suse.com>
+---
+ salt/ext/tornado/httputil.py           | 56 ++++++++++++++++++--------
+ salt/ext/tornado/test/httputil_test.py | 38 +++++++++++++++++
+ salt/utils/nxos.py                     |  3 +-
+ 3 files changed, 79 insertions(+), 18 deletions(-)
+
+diff --git a/salt/ext/tornado/httputil.py b/salt/ext/tornado/httputil.py
+index 4866b0c991..78953c5f6b 100644
+--- a/salt/ext/tornado/httputil.py
++++ b/salt/ext/tornado/httputil.py
+@@ -139,8 +139,8 @@ class HTTPHeaders(MutableMapping):
+     """
+ 
+     def __init__(self, *args, **kwargs):
+-        self._dict = {}  # type: typing.Dict[str, str]
+         self._as_list = {}  # type: typing.Dict[str, typing.List[str]]
++        self._combined_cache = {} # type: typing.Dict[str, str]
+         self._last_key = None
+         if len(args) == 1 and len(kwargs) == 0 and isinstance(args[0], HTTPHeaders):
+             # Copy constructor
+@@ -158,9 +158,7 @@ class HTTPHeaders(MutableMapping):
+         norm_name = _normalized_headers[name]
+         self._last_key = norm_name
+         if norm_name in self:
+-            self._dict[norm_name] = (
+-                native_str(self[norm_name]) + "," + native_str(value)
+-            )
++            self._combined_cache.pop(norm_name, None)
+             self._as_list[norm_name].append(value)
+         else:
+             self[norm_name] = value
+@@ -193,7 +191,7 @@ class HTTPHeaders(MutableMapping):
+             # continuation of a multi-line header
+             new_part = " " + line.lstrip(HTTP_WHITESPACE)
+             self._as_list[self._last_key][-1] += new_part
+-            self._dict[self._last_key] += new_part
++            self._combined_cache.pop(self._last_key, None)
+         else:
+             name, value = line.split(":", 1)
+             self.add(name, value.strip(HTTP_WHITESPACE))
+@@ -216,23 +214,33 @@ class HTTPHeaders(MutableMapping):
+ 
+     def __setitem__(self, name, value):
+         norm_name = _normalized_headers[name]
+-        self._dict[norm_name] = value
++        self._combined_cache[norm_name] = value
+         self._as_list[norm_name] = [value]
+ 
++    def __contains__(self, name):
++        # This is an important optimization to avoid the expensive concatenation
++        # in __getitem__ when it's not needed.
++        if not isinstance(name, str):
++            return False
++        return name in self._as_list
++
+     def __getitem__(self, name):
+         # type: (str) -> str
+-        return self._dict[_normalized_headers[name]]
++        header = _normalized_headers[name]
++        if header not in self._combined_cache:
++            self._combined_cache[header] = ",".join(self._as_list[header])
++        return self._combined_cache[header]
+ 
+     def __delitem__(self, name):
+         norm_name = _normalized_headers[name]
+-        del self._dict[norm_name]
++        del self._combined_cache[norm_name]
+         del self._as_list[norm_name]
+ 
+     def __len__(self):
+-        return len(self._dict)
++        return len(self._as_list)
+ 
+     def __iter__(self):
+-        return iter(self._dict)
++        return iter(self._as_list)
+ 
+     def copy(self):
+         # defined in dict but not in MutableMapping.
+@@ -894,19 +902,33 @@ def parse_response_start_line(line):
+ # combinations of semicolons and double quotes.
+ # It has also been modified to support valueless parameters as seen in
+ # websocket extension negotiations.
++#
++# _parseparam has been further modified with the logic from
++# https://github.com/python/cpython/pull/136072/files
++# to avoid quadratic behavior when parsing semicolons in quoted strings.
++#
++# TODO: See if we can switch to email.message.Message for this functionality.
++# This is the suggested replacement for the cgi.py module now that cgi has
++# been removed from recent versions of Python.  We need to verify that
++# the email module is consistent with our existing behavior (and all relevant
+ 
+ 
+ def _parseparam(s):
+-    while s[:1] == ";":
+-        s = s[1:]
+-        end = s.find(";")
+-        while end > 0 and (s.count('"', 0, end) - s.count('\\"', 0, end)) % 2:
+-            end = s.find(";", end + 1)
++    start = 0
++    while s.find(";", start) == start:
++        start += 1
++        end = s.find(";", start)
++        ind, diff = start, 0
++        while end > 0:
++            diff += s.count('"', ind, end) - s.count('\\"', ind, end)
++            if diff % 2 == 0:
++                break
++            end, ind = ind, s.find(";", end + 1)
+         if end < 0:
+             end = len(s)
+-        f = s[:end]
++        f = s[start:end]
+         yield f.strip()
+-        s = s[end:]
++        start = end
+ 
+ 
+ def _parse_header(line):
+diff --git a/salt/ext/tornado/test/httputil_test.py b/salt/ext/tornado/test/httputil_test.py
+index c613b4e41a..bdbfaa2b6a 100644
+--- a/salt/ext/tornado/test/httputil_test.py
++++ b/salt/ext/tornado/test/httputil_test.py
+@@ -245,6 +245,30 @@ Foo
+         self.assertEqual(file["body"], b"Foo")
+ 
+ 
++    def test_disposition_param_linear_performance(self):
++        # This is a regression test for performance of parsing parameters
++        # to the content-disposition header, specifically for semicolons within
++        # quoted strings.
++        def f(n):
++            start = time.time()
++            message = (
++                b"--1234\r\nContent-Disposition: form-data; "
++                + b'x="'
++                + b";" * n
++                + b'"; '
++                + b'name="files"; filename="a.txt"\r\n\r\nFoo\r\n--1234--\r\n'
++            )
++            args: dict[str, list[bytes]] = {}
++            files: dict[str, list[HTTPFile]] = {}
++            parse_multipart_form_data(b"1234", message, args, files)
++            return time.time() - start
++
++        d1 = f(1_000)
++        d2 = f(10_000)
++        if d2 / d1 > 20:
++            self.fail(f"Disposition param parsing is not linear: {d1=} vs {d2=}")
++
++
+ class HTTPHeadersTest(unittest.TestCase):
+     def test_multi_line(self):
+         # Lines beginning with whitespace are appended to the previous line
+@@ -367,6 +391,20 @@ Foo: even
+         headers2 = HTTPHeaders.parse(str(headers))
+         self.assertEquals(headers, headers2)
+ 
++    def test_linear_performance(self):
++        def f(n):
++            start = time.time()
++            headers = HTTPHeaders()
++            for i in range(n):
++                headers.add("X-Foo", "bar")
++            return time.time() - start
++
++        # This runs under 50ms on my laptop as of 2025-12-09.
++        d1 = f(10000)
++        d2 = f(100000)
++        if d2 / d1 > 20:
++            # d2 should be about 10x d1 but allow a wide margin for variability.
++            self.fail("HTTPHeaders.add() does not scale linearly: %s vs %s" % (d1, d2))
+ 
+ class FormatTimestampTest(unittest.TestCase):
+     # Make sure that all the input types are supported.
+diff --git a/salt/utils/nxos.py b/salt/utils/nxos.py
+index 2572a76267..654290155e 100644
+--- a/salt/utils/nxos.py
++++ b/salt/utils/nxos.py
+@@ -212,7 +212,8 @@ class NxapiClient:
+             body = response
+ 
+         if self.nxargs["connect_over_uds"]:
+-            body = json.loads(response.read().decode("utf-8"))
++            max_safe_read = 10 * 1024 * 1024
++            body = json.loads(response.read(max_safe_read).decode("utf-8"))
+ 
+         # Proceed with caution.  The JSON may not be complete.
+         # Don't just return body['ins_api']['outputs']['output'] directly.
+-- 
+2.52.0
+

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -591,6 +591,14 @@ Patch185:       do-not-break-signature-verification-on-latest-m2cryp.patch
 Patch186:       fix-salt-for-python-3.11.patch
 # PATCH-FIX_OPENSUSE: https://github.com/openSUSE/salt/pull/737
 Patch187:       fix-tls-and-x509-modules-for-older-cryptography-modu.patch
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/issues/68377
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/issues/68379
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/issues/68383
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/issues/68467
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/issues/68469
+# PATCH-FIX_OPENSUSE: https://github.com/openSUSE/salt/pull/739
+Patch188:       backport-3006.17-security-fixes-739.patch
+
 
 ### IMPORTANT: The line below is used as a snippet marker. Do not touch it.
 ### SALT PATCHES LIST END

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -611,6 +611,8 @@ Patch191:       fixes-for-security-issues-cve-2025-13836-cve-2025-67.patch
 Patch192:       speedup-wheel-key.finger-call-bsc-1240532-713.patch
 # PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/67956
 Patch193:       use-internal-salt.utils.pkg.deb-classes-instead-of-a.patch
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/66964
+Patch194:       backport-add-maintain-m-privilege-to-postgres-module.patch
 
 
 ### IMPORTANT: The line below is used as a snippet marker. Do not touch it.

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -601,7 +601,12 @@ Patch188:       backport-3006.17-security-fixes-739.patch
 # PATCH-FIX_OPENSUSE: https://github.com/openSUSE/salt/pull/742
 Patch189:       extend-fails-to-warnings-until-2027-742.patch
 # PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/68253
-Patch190: simplify-utils.json.find_json-function.patch
+Patch190:       simplify-utils.json.find_json-function.patch
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/68595
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/68611
+# PATCH-FIX_UPSTREAM: https://github.com/tornadoweb/tornado/pull/3553
+# PATCH-FIX_UPSTREAM: https://github.com/tornadoweb/tornado/commit/771472cfdaeebc0d89a9cc46e249f8891a6b29cd
+Patch191:       fixes-for-security-issues-cve-2025-13836-cve-2025-67.patch
 
 
 ### IMPORTANT: The line below is used as a snippet marker. Do not touch it.

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -613,6 +613,8 @@ Patch192:       speedup-wheel-key.finger-call-bsc-1240532-713.patch
 Patch193:       use-internal-salt.utils.pkg.deb-classes-instead-of-a.patch
 # PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/66964
 Patch194:       backport-add-maintain-m-privilege-to-postgres-module.patch
+# PATCH-FIX_OPENSUSE: https://github.com/openSUSE/salt/pull/745
+Patch195:       fix-tornado-s-httputil_test-syntax-for-python-3.6.patch
 
 
 ### IMPORTANT: The line below is used as a snippet marker. Do not touch it.

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -600,6 +600,8 @@ Patch187:       fix-tls-and-x509-modules-for-older-cryptography-modu.patch
 Patch188:       backport-3006.17-security-fixes-739.patch
 # PATCH-FIX_OPENSUSE: https://github.com/openSUSE/salt/pull/742
 Patch189:       extend-fails-to-warnings-until-2027-742.patch
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/68253
+Patch190: simplify-utils.json.find_json-function.patch
 
 
 ### IMPORTANT: The line below is used as a snippet marker. Do not touch it.

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -598,6 +598,8 @@ Patch187:       fix-tls-and-x509-modules-for-older-cryptography-modu.patch
 # PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/issues/68469
 # PATCH-FIX_OPENSUSE: https://github.com/openSUSE/salt/pull/739
 Patch188:       backport-3006.17-security-fixes-739.patch
+# PATCH-FIX_OPENSUSE: https://github.com/openSUSE/salt/pull/742
+Patch189:       extend-fails-to-warnings-until-2027-742.patch
 
 
 ### IMPORTANT: The line below is used as a snippet marker. Do not touch it.

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -609,6 +609,8 @@ Patch190:       simplify-utils.json.find_json-function.patch
 Patch191:       fixes-for-security-issues-cve-2025-13836-cve-2025-67.patch
 # PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/68251
 Patch192:       speedup-wheel-key.finger-call-bsc-1240532-713.patch
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/67956
+Patch193:       use-internal-salt.utils.pkg.deb-classes-instead-of-a.patch
 
 
 ### IMPORTANT: The line below is used as a snippet marker. Do not touch it.

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -1144,7 +1144,7 @@ Requires:       %{python_module pygit2}
 Requires:       %{python_module pytest >= 7.0.1}
 Requires:       %{python_module pytest-httpserver}
 Requires:       %{python_module pytest-salt-factories >= 1.0.0~rc21}
-Requires:       %{python_module pytest-subtests}
+Requires:       %{python_module pytest-subtests if %python-pytest < 9}
 Requires:       %{python_module testinfra}
 Requires:       %{python_module yamllint}
 Requires:       %{python_module pip}
@@ -1160,11 +1160,13 @@ Requires:       python-docker
 %if 0%{?suse_version} < 1600
 Requires:       python-mock
 %endif
+%if 0%{?suse_version} <= 1600
+Requires:       python-pytest-subtests
+%endif
 Requires:       python-pygit2
 Requires:       python-pytest >= 7.0.1
 Requires:       python-pytest-httpserver
 Requires:       python-pytest-salt-factories >= 1.0.0~rc21
-Requires:       python-pytest-subtests
 Requires:       python-testinfra
 Requires:       python-yamllint
 Requires:       python-pip

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -607,6 +607,8 @@ Patch190:       simplify-utils.json.find_json-function.patch
 # PATCH-FIX_UPSTREAM: https://github.com/tornadoweb/tornado/pull/3553
 # PATCH-FIX_UPSTREAM: https://github.com/tornadoweb/tornado/commit/771472cfdaeebc0d89a9cc46e249f8891a6b29cd
 Patch191:       fixes-for-security-issues-cve-2025-13836-cve-2025-67.patch
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/68251
+Patch192:       speedup-wheel-key.finger-call-bsc-1240532-713.patch
 
 
 ### IMPORTANT: The line below is used as a snippet marker. Do not touch it.

--- a/salt/simplify-utils.json.find_json-function.patch
+++ b/salt/simplify-utils.json.find_json-function.patch
@@ -1,0 +1,173 @@
+From 7cbb68f36824161743f4cc60d8920e2cea039e5e Mon Sep 17 00:00:00 2001
+From: Marek Czernek <marek.czernek@suse.com>
+Date: Fri, 9 Jan 2026 16:49:19 +0100
+Subject: [PATCH] Simplify utils.json.find_json function
+
+The previous implementation computed all combinations of potential JSON
+documents and tried to `json.loads()`them. That resumted in num({) *
+num(}) tries, which could take hours on large inputs.
+
+The approach implemented with this change simplifies the work we do: we
+only look for opening '{' and '[' characters, and try to parse the rest
+of input string with JSONDecoder.raw_decode. This method ignores
+extraneous data at the end and is faster than doing it ourselves in
+Python.
+
+Co-authored-by: Alexander Graul <agraul@suse.com>
+---
+ changelog/68258.fixed.md              |  1 +
+ salt/utils/json.py                    | 80 ++++++---------------------
+ tests/pytests/unit/utils/test_json.py |  5 --
+ tests/unit/utils/test_json.py         | 12 ++++
+ 4 files changed, 31 insertions(+), 67 deletions(-)
+ create mode 100644 changelog/68258.fixed.md
+
+diff --git a/changelog/68258.fixed.md b/changelog/68258.fixed.md
+new file mode 100644
+index 0000000000..a9afeccef7
+--- /dev/null
++++ b/changelog/68258.fixed.md
+@@ -0,0 +1 @@
++Simplied and sped up `utils.json.find_json` function
+diff --git a/salt/utils/json.py b/salt/utils/json.py
+index 26cb38cdbe..1605e75f9f 100644
+--- a/salt/utils/json.py
++++ b/salt/utils/json.py
+@@ -2,7 +2,7 @@
+ Functions to work with JSON
+ """
+ 
+-
++import contextlib
+ import json
+ import logging
+ 
+@@ -25,69 +25,25 @@ def __split(raw):
+     return raw.splitlines()
+ 
+ 
+-def find_json(raw):
+-    """
+-    Pass in a raw string and load the json when it starts. This allows for a
+-    string to start with garbage and end with json but be cleanly loaded
+-    """
+-    ret = {}
+-    lines = __split(raw)
+-    lengths = list(map(len, lines))
+-    starts = []
+-    ends = []
+-
+-    # Search for possible starts end ends of the json fragments
+-    for ind, _ in enumerate(lines):
+-        line = lines[ind].lstrip()
+-        line = line[0] if line else line
+-        if line == "{" or line == "[":
+-            starts.append((ind, line))
+-        if line == "}" or line == "]":
+-            ends.append((ind, line))
+-
+-    # List all the possible pairs of starts and ends,
+-    # and fill the length of each block to sort by size after
+-    starts_ends = []
+-    for start, start_br in starts:
+-        for end, end_br in reversed(ends):
+-            if end > start and (
+-                (start_br == "{" and end_br == "}")
+-                or (start_br == "[" and end_br == "]")
+-            ):
+-                starts_ends.append((start, end, sum(lengths[start : end + 1])))
+-
+-    # Iterate through all the possible pairs starting from the largest
+-    starts_ends.sort(key=lambda x: (x[2], x[1] - x[0], x[0]), reverse=True)
+-    for start, end, _ in starts_ends:
+-        working = "\n".join(lines[start : end + 1])
+-        try:
+-            ret = json.loads(working)
+-            return ret
+-        except ValueError:
+-            pass
+-        # Try filtering non-JSON text right after the last closing curly brace
+-        end_str = lines[end].lstrip()[0]
+-        working = "\n".join(lines[start : end]) + end_str
+-        try:
+-            ret = json.loads(working)
+-            return ret
+-        except ValueError:
+-            continue
++def find_json(s: str):
++    """Pass in a string and load JSON within it.
+ 
+-    # Fall back to old implementation for backward compatibility
+-    # excpecting json after the text
+-    for ind, _ in enumerate(lines):
+-        working = "\n".join(lines[ind:])
+-        try:
+-            ret = json.loads(working)
+-        except ValueError:
+-            continue
+-        if ret:
+-            return ret
++    The string may contain non-JSON text before and after the JSON document.
+ 
+-    if not ret:
+-        # Not json, raise an error
+-        raise ValueError
++    Raises ValueError if no valid JSON was found.
++    """
++    decoder = json.JSONDecoder()
++
++    # We look for the beginning of JSON objects / arrays and let raw_decode() handle
++    # extraneous data at the end.
++    for idx, char in enumerate(s):
++        if char == "{" or char == "[":
++            # JSONDecodeErrors are expected on stray '{'/'[' in the non-JSON part
++            with contextlib.suppress(json.JSONDecodeError):
++                data, _ = decoder.raw_decode(s[idx:])
++                return data
++
++    raise ValueError
+ 
+ 
+ def import_json():
+diff --git a/tests/pytests/unit/utils/test_json.py b/tests/pytests/unit/utils/test_json.py
+index 72b1023003..f7aed28b42 100644
+--- a/tests/pytests/unit/utils/test_json.py
++++ b/tests/pytests/unit/utils/test_json.py
+@@ -107,11 +107,6 @@ def test_find_json():
+     ret = salt.utils.json.find_json(garbage_around_json)
+     assert ret == expected_ret
+ 
+-    # Now pre-pend small json and re-test
+-    small_json_pre_json = f"{test_small_json}{test_sample_json}"
+-    ret = salt.utils.json.find_json(small_json_pre_json)
+-    assert ret == expected_ret
+-
+     # Now post-pend small json and re-test
+     small_json_post_json = f"{test_sample_json}{test_small_json}"
+     ret = salt.utils.json.find_json(small_json_post_json)
+diff --git a/tests/unit/utils/test_json.py b/tests/unit/utils/test_json.py
+index 5ea409a705..f5dcc1f72d 100644
+--- a/tests/unit/utils/test_json.py
++++ b/tests/unit/utils/test_json.py
+@@ -49,6 +49,18 @@ class JSONTestCase(TestCase):
+         )
+     )
+ 
++    def test_find_json_unbalanced_brace_in_string(self):
++        test_sample_json = '{"title": "I like curly braces like this one:{"}'
++        expected_ret = {"title": "I like curly braces like this one:{"}
++        ret = salt.utils.json.find_json(test_sample_json)
++        self.assertDictEqual(ret, expected_ret)
++
++    def test_find_json_unbalanced_square_bracket_in_string(self):
++        test_sample_json = '{"title": "I like square brackets like this one:["}'
++        expected_ret = {"title": "I like square brackets like this one:["}
++        ret = salt.utils.json.find_json(test_sample_json)
++        self.assertDictEqual(ret, expected_ret)
++
+     def test_find_json(self):
+         test_sample_json = """
+                             {
+-- 
+2.52.0
+

--- a/salt/speedup-wheel-key.finger-call-bsc-1240532-713.patch
+++ b/salt/speedup-wheel-key.finger-call-bsc-1240532-713.patch
@@ -1,0 +1,91 @@
+From c4542e59844bce3a65726564fa364170c1fe7b8c Mon Sep 17 00:00:00 2001
+From: Victor Zhestkov <vzhestkov@suse.com>
+Date: Wed, 14 Jan 2026 14:12:44 +0100
+Subject: [PATCH] Speedup wheel key.finger call (bsc#1240532) (#713)
+
+* Reduce the number of os.path.basename calls with key.finger
+
+* Simplify and speedup salt.key.Key.name_match
+
+* Avoid not needed printing while calling wheel from master
+
+* Populate missing parts for clear_load
+
+* Remove redundant events to be fired
+---
+ salt/key.py    | 20 ++++++++++----------
+ salt/master.py | 11 ++++++++---
+ 2 files changed, 18 insertions(+), 13 deletions(-)
+
+diff --git a/salt/key.py b/salt/key.py
+index b15b80eca3..8cd248bb8c 100644
+--- a/salt/key.py
++++ b/salt/key.py
+@@ -491,16 +491,15 @@ class Key:
+         ret = {}
+         if "," in match and isinstance(match, str):
+             match = match.split(",")
++        if not isinstance(match, list):
++            match = [match]
+         for status, keys in matches.items():
++            if match == ["*"] and keys:
++                ret[status] = keys
++                continue
+             for key in salt.utils.data.sorted_ignorecase(keys):
+-                if isinstance(match, list):
+-                    for match_item in match:
+-                        if fnmatch.fnmatch(key, match_item):
+-                            if status not in ret:
+-                                ret[status] = []
+-                            ret[status].append(key)
+-                else:
+-                    if fnmatch.fnmatch(key, match):
++                for match_item in match:
++                    if fnmatch.fnmatch(key, match_item):
+                         if status not in ret:
+                             ret[status] = []
+                         ret[status].append(key)
+@@ -543,12 +542,13 @@ class Key:
+         for dir_ in key_dirs:
+             if dir_ is None:
+                 continue
+-            ret[os.path.basename(dir_)] = []
++            base_dir = os.path.basename(dir_)
++            ret[base_dir] = []
+             try:
+                 for fn_ in salt.utils.data.sorted_ignorecase(os.listdir(dir_)):
+                     if not fn_.startswith("."):
+                         if os.path.isfile(os.path.join(dir_, fn_)):
+-                            ret[os.path.basename(dir_)].append(
++                            ret[base_dir].append(
+                                 salt.utils.stringutils.to_unicode(fn_)
+                             )
+             except OSError:
+diff --git a/salt/master.py b/salt/master.py
+index 09ce7d36a7..b9f009a028 100644
+--- a/salt/master.py
++++ b/salt/master.py
+@@ -2093,12 +2093,17 @@ class ClearFuncs(TransportMethods):
+                 "tag": tag,
+                 "user": username,
+             }
+-
+-            self.event.fire_event(data, tagify([jid, "new"], "wheel"))
++            clear_load.update(
++                {
++                    "__jid__": jid,
++                    "__tag__": tag,
++                    "__user__": username,
++                    "print_event": clear_load.get("print_event", False),
++                }
++            )
+             ret = self.wheel_.call_func(fun, full_return=True, **clear_load)
+             data["return"] = ret["return"]
+             data["success"] = ret["success"]
+-            self.event.fire_event(data, tagify([jid, "ret"], "wheel"))
+             return {"tag": tag, "data": data}
+         except Exception as exc:  # pylint: disable=broad-except
+             log.error("Exception occurred while introspecting %s: %s", fun, exc)
+-- 
+2.52.0
+

--- a/salt/use-internal-salt.utils.pkg.deb-classes-instead-of-a.patch
+++ b/salt/use-internal-salt.utils.pkg.deb-classes-instead-of-a.patch
@@ -1,0 +1,3360 @@
+From 23959f695c33628c974a799050abf3325beaa2ec Mon Sep 17 00:00:00 2001
+From: Victor Zhestkov <vzhestkov@suse.com>
+Date: Wed, 14 Jan 2026 14:34:02 +0100
+Subject: [PATCH] Use internal salt.utils.pkg.deb classes instead of aptsource
+ (#711)
+
+* Fix 2 pkgrepo.absent bugs for apt-based distros
+
+* Do grains check and call imported utility function
+
+* initial removal of python librarys that only exist in debian system python, not done yet
+
+remove unused functions
+
+add pkg.which for deb packages. an item from pkng that should have spread to systems that support it
+
+move SourcesList and SourceEntry to salt.utils.pkg.deb where it belongs.
+
+fix pkg.which test hopfully coreutils is installed
+
+first attempt at fixng #65703
+
+add first changelogs
+
+fix the indexing issue with deb opts by using OrderedDict instead
+
+move salt.utils.pkg.deb tests to functional since not actually unit test.
+
+use example.com instead of real repo in tests.
+
+fix changelog 65703
+
+added changelog for 66201
+
+fix two to many toos in changelog
+
+* Make aptpkg using salt.utils.pkg.deb classes
+
+* Fixes for test_aptpkg
+
+* tiny fix for the test
+
+* Simplify deb822 implementation
+
+* Remove hard requirement for signedby on test repo mod
+
+as it's actually causing impossibility to modify existing entries
+
+* Fix duplicated test_sourceslist_multiple_comps
+
+* Define repo dict in one shot
+
+* Apply the suggestion for string_to_bool to make it cleaner
+
+* Fix wrongly modified regex in get_opts
+
+* Fix issues found with pre-commit check
+
+* Fix distorted test_mod_repo_enabled
+
+* Make `file` not mandatory on repo creation
+
+as using sources.list as default is still possible
+
+* Remove unnecessary parts from SourcesList implementation
+
+* Fix signed-by typo
+
+* Remove unused disabled compat
+
+* Return raw string modification for legacy source
+
+* Revert order change of opts
+
+* Remove explicit redundant section for trusted
+
+* Accept either list or str as comment on creation
+
+* Add comment why it makes sense to call apt-get clean
+
+* Fix docstring for string_to_bool
+
+* Use groups for regexp matching
+
+* Add multiple URIs support for deb822
+
+* Remove redundant part of rendering list_repos
+
+* Remove aptsources with/without
+
+* Test pkgrepo.managed with deb822
+
+* Improve deb822 repo management
+
+* Remove unused imports from test_debian
+
+* Add uris to MockSourceEntry
+
+* Fix test_aptpkg
+
+* Do not put empty values to deb822 section
+
+* Fix missing definition
+
+* Fix test_aptpkg.py
+
+* Add trusted param
+
+* Throw error when user defines incorrect deb line
+
+---------
+
+Co-authored-by: Erik Johnson <palehose@gmail.com>
+Co-authored-by: Thomas Phipps <thomas.phipps@broadcom.com>
+Co-authored-by: Marek Czernek <marek.czernek@suse.com>
+---
+ changelog/64286.fixed.md                      |   1 +
+ changelog/65703.fixed.md                      |   1 +
+ changelog/66056.changed.md                    |   1 +
+ changelog/66201.added.md                      |   1 +
+ salt/modules/aptpkg.py                        | 926 ++++++------------
+ salt/states/pkgrepo.py                        |  43 +-
+ salt/utils/pkg/deb.py                         | 801 +++++++++++++++
+ tests/pytests/functional/modules/test_pkg.py  |   9 +-
+ .../functional/states/pkgrepo/test_debian.py  | 400 +++++---
+ .../pytests/functional/utils/pkg/__init__.py  |   0
+ .../pytests/functional/utils/pkg/test_deb.py  |  88 ++
+ tests/pytests/unit/modules/test_aptpkg.py     | 176 ++--
+ 12 files changed, 1570 insertions(+), 877 deletions(-)
+ create mode 100644 changelog/64286.fixed.md
+ create mode 100644 changelog/65703.fixed.md
+ create mode 100644 changelog/66056.changed.md
+ create mode 100644 changelog/66201.added.md
+ create mode 100644 tests/pytests/functional/utils/pkg/__init__.py
+ create mode 100644 tests/pytests/functional/utils/pkg/test_deb.py
+
+diff --git a/changelog/64286.fixed.md b/changelog/64286.fixed.md
+new file mode 100644
+index 0000000000..1ea343c38d
+--- /dev/null
++++ b/changelog/64286.fixed.md
+@@ -0,0 +1 @@
++Fix 2 pkgrepo.absent bugs for apt-based distros
+diff --git a/changelog/65703.fixed.md b/changelog/65703.fixed.md
+new file mode 100644
+index 0000000000..091c754114
+--- /dev/null
++++ b/changelog/65703.fixed.md
+@@ -0,0 +1 @@
++fix 65703 by using OrderedDict instead of a index that breaks. .
+diff --git a/changelog/66056.changed.md b/changelog/66056.changed.md
+new file mode 100644
+index 0000000000..f088b055cd
+--- /dev/null
++++ b/changelog/66056.changed.md
+@@ -0,0 +1 @@
++re-work the aptpkg module to remove system libraries that onedir and virtualenvs do not have access. Streamline testing, and code use to needed libraries only.
+diff --git a/changelog/66201.added.md b/changelog/66201.added.md
+new file mode 100644
+index 0000000000..1a5738512a
+--- /dev/null
++++ b/changelog/66201.added.md
+@@ -0,0 +1 @@
++added pkg.which to aptpkg, for finding which package installed a file.
+diff --git a/salt/modules/aptpkg.py b/salt/modules/aptpkg.py
+index f7884d9ccd..2775c32177 100644
+--- a/salt/modules/aptpkg.py
++++ b/salt/modules/aptpkg.py
+@@ -6,8 +6,6 @@ Support for APT (Advanced Packaging Tool)
+     minion, and it is using a different module (or gives an error similar to
+     *'pkg.install' is not available*), see :ref:`here
+     <module-provider-override>`.
+-
+-    For repository management, the ``python-apt`` package must be installed.
+ """
+ 
+ import copy
+@@ -18,14 +16,11 @@ import os
+ import pathlib
+ import re
+ import shutil
+-import tempfile
+ import time
+ from urllib.error import HTTPError
+ from urllib.request import Request as _Request
+ from urllib.request import urlopen as _urlopen
+ 
+-import salt.config
+-import salt.syspaths
+ import salt.utils.args
+ import salt.utils.data
+ import salt.utils.environment
+@@ -48,42 +43,17 @@ from salt.exceptions import (
+ )
+ from salt.modules.cmdmod import _parse_env
+ from salt.utils.versions import warn_until_date
++from salt.utils.pkg.deb import (
++    Deb822Section,
++    Deb822SourceEntry,
++    SourceEntry,
++    SourcesList,
++    _invalid,
++    string_to_bool,
++)
+ 
+ log = logging.getLogger(__name__)
+ 
+-# pylint: disable=import-error
+-try:
+-    from aptsources.sourceslist import SourceEntry, SourcesList
+-
+-    HAS_APT = True
+-except ImportError:
+-    HAS_APT = False
+-
+-HAS_DEB822 = False
+-
+-if HAS_APT:
+-    try:
+-        from aptsources.sourceslist import Deb822SourceEntry, _deb822
+-
+-        HAS_DEB822 = True
+-    except ImportError:
+-        pass
+-
+-try:
+-    import apt_pkg
+-
+-    HAS_APTPKG = True
+-except ImportError:
+-    HAS_APTPKG = False
+-
+-try:
+-    import softwareproperties.ppa
+-
+-    HAS_SOFTWAREPROPERTIES = True
+-except ImportError:
+-    HAS_SOFTWAREPROPERTIES = False
+-# pylint: enable=import-error
+-
+ APT_LISTS_PATH = "/var/lib/apt/lists"
+ PKG_ARCH_SEPARATOR = ":"
+ 
+@@ -92,7 +62,22 @@ LP_SRC_FORMAT = "deb http://ppa.launchpad.net/{0}/{1}/ubuntu {2} main"
+ LP_PVT_SRC_FORMAT = "deb https://{0}private-ppa.launchpad.net/{1}/{2}/ubuntu {3} main"
+ 
+ _MODIFY_OK = frozenset(
+-    ["uri", "comps", "architectures", "disabled", "file", "dist", "signedby"]
++    [
++        "uri",
++        "uris",
++        "comps",
++        "architectures",
++        "disabled",
++        "file",
++        "dist",
++        "suites",
++        "signedby",
++        "trusted",
++        "types",
++    ]
++)
++_MODIFY_OK_LEGACY = frozenset(
++    ["uri", "comps", "architectures", "disabled", "file", "dist", "signedby", "trusted"]
+ )
+ DPKG_ENV_VARS = {
+     "APT_LISTBUGS_FRONTEND": "none",
+@@ -131,201 +116,6 @@ def __init__(opts):
+         os.environ.update(DPKG_ENV_VARS)
+ 
+ 
+-def _invalid(line):
+-    """
+-    This is a workaround since python3-apt does not support
+-    the signed-by argument. This function was removed from
+-    the class to ensure users using the python3-apt module or
+-    not can use the signed-by option.
+-    """
+-    disabled = False
+-    invalid = False
+-    comment = ""
+-    line = line.strip()
+-    if not line:
+-        invalid = True
+-        return disabled, invalid, comment, ""
+-
+-    if line.startswith("#"):
+-        disabled = True
+-        line = line[1:]
+-
+-    idx = line.find("#")
+-    if idx > 0:
+-        comment = line[idx + 1 :]
+-        line = line[:idx]
+-
+-    cdrom_match = re.match(r"(.*)(cdrom:.*/)(.*)", line.strip())
+-    if cdrom_match:
+-        repo_line = (
+-            [p.strip() for p in cdrom_match.group(1).split()]
+-            + [cdrom_match.group(2).strip()]
+-            + [p.strip() for p in cdrom_match.group(3).split()]
+-        )
+-    else:
+-        repo_line = line.strip().split()
+-    if (
+-        not repo_line
+-        or repo_line[0] not in ["deb", "deb-src", "rpm", "rpm-src"]
+-        or len(repo_line) < 3
+-    ):
+-        invalid = True
+-        return disabled, invalid, comment, repo_line
+-
+-    if repo_line[1].startswith("["):
+-        if not any(x.endswith("]") for x in repo_line[1:]):
+-            invalid = True
+-            return disabled, invalid, comment, repo_line
+-
+-    return disabled, invalid, comment, repo_line
+-
+-
+-if not HAS_APT:
+-
+-    class SourceEntry:  # pylint: disable=function-redefined
+-        def __init__(self, line, file=None):
+-            self.invalid = False
+-            self.comps = []
+-            self.disabled = False
+-            self.comment = ""
+-            self.dist = ""
+-            self.type = ""
+-            self.uri = ""
+-            self.line = line
+-            self.architectures = []
+-            self.signedby = ""
+-            self.file = file
+-            if not self.file:
+-                self.file = str(pathlib.Path(os.sep, "etc", "apt", "sources.list"))
+-            self._parse_sources(line)
+-
+-        def str(self):
+-            return self.repo_line()
+-
+-        def repo_line(self):
+-            """
+-            Return the repo line for the sources file
+-            """
+-            repo_line = []
+-            if self.invalid:
+-                return self.line
+-            if self.disabled:
+-                repo_line.append("#")
+-
+-            repo_line.append(self.type)
+-            opts = []
+-            if self.architectures:
+-                opts.append("arch={}".format(",".join(self.architectures)))
+-            if self.signedby:
+-                opts.append("signed-by={}".format(self.signedby))
+-
+-            if opts:
+-                repo_line.append("[{}]".format(" ".join(opts)))
+-
+-            repo_line = repo_line + [self.uri, self.dist, " ".join(self.comps)]
+-            if self.comment:
+-                repo_line.append("#{}".format(self.comment))
+-            return " ".join(repo_line) + "\n"
+-
+-        def _parse_sources(self, line):
+-            """
+-            Parse lines from sources files
+-            """
+-            self.disabled, self.invalid, self.comment, repo_line = _invalid(line)
+-            if self.invalid:
+-                return False
+-            if repo_line[1].startswith("["):
+-                repo_line = [x for x in (line.strip("[]") for line in repo_line) if x]
+-                opts = _get_opts(self.line)
+-                self.architectures.extend(opts["arch"]["value"])
+-                self.signedby = opts["signedby"]["value"]
+-                for opt in opts.keys():
+-                    opt = opts[opt]["full"]
+-                    if opt:
+-                        try:
+-                            repo_line.pop(repo_line.index(opt))
+-                        except ValueError:
+-                            repo_line.pop(repo_line.index("[" + opt + "]"))
+-            self.type = repo_line[0]
+-            self.uri = repo_line[1]
+-            self.dist = repo_line[2]
+-            self.comps = repo_line[3:]
+-            return True
+-
+-    class SourcesList:  # pylint: disable=function-redefined
+-        def __init__(self):
+-            self.list = []
+-            self.files = [
+-                pathlib.Path(os.sep, "etc", "apt", "sources.list"),
+-                pathlib.Path(os.sep, "etc", "apt", "sources.list.d"),
+-            ]
+-            for file in self.files:
+-                if file.is_dir():
+-                    for fp in file.glob("**/*.list"):
+-                        self.add_file(file=fp)
+-                else:
+-                    self.add_file(file)
+-
+-        def __iter__(self):
+-            yield from self.list
+-
+-        def add_file(self, file):
+-            """
+-            Add the lines of a file to self.list
+-            """
+-            if file.is_file():
+-                with salt.utils.files.fopen(str(file)) as source:
+-                    for line in source:
+-                        self.list.append(SourceEntry(line, file=str(file)))
+-            else:
+-                log.debug("The apt sources file %s does not exist", file)
+-
+-        def add(self, type, uri, dist, orig_comps, architectures, signedby):
+-            opts_count = []
+-            opts_line = ""
+-            if architectures:
+-                architectures = "arch={}".format(",".join(architectures))
+-                opts_count.append(architectures)
+-            if signedby:
+-                signedby = "signed-by={}".format(signedby)
+-                opts_count.append(signedby)
+-            if len(opts_count) > 1:
+-                opts_line = "[" + " ".join(opts_count) + "]"
+-            elif len(opts_count) == 1:
+-                opts_line = "[" + "".join(opts_count) + "]"
+-            repo_line = [
+-                type,
+-                opts_line,
+-                uri,
+-                dist,
+-                " ".join(orig_comps),
+-            ]
+-            return SourceEntry(" ".join([line for line in repo_line if line.strip()]))
+-
+-        def remove(self, source):
+-            """
+-            remove a source from the list of sources
+-            """
+-            self.list.remove(source)
+-
+-        def save(self):
+-            """
+-            write all of the sources from the list of sources
+-            to the file.
+-            """
+-            filemap = {}
+-            with tempfile.TemporaryDirectory() as tmpdir:
+-                for source in self.list:
+-                    fname = pathlib.Path(tmpdir, pathlib.Path(source.file).name)
+-                    with salt.utils.files.fopen(str(fname), "a") as fp:
+-                        fp.write(source.repo_line())
+-                    if source.file not in filemap:
+-                        filemap[source.file] = {"tmp": fname}
+-
+-                for fp in filemap:
+-                    shutil.move(str(filemap[fp]["tmp"]), fp)
+-
+-
+ def _get_ppa_info_from_launchpad(owner_name, ppa_name):
+     """
+     Idea from softwareproperties.ppa.
+@@ -338,21 +128,12 @@ def _get_ppa_info_from_launchpad(owner_name, ppa_name):
+     :return:
+     """
+ 
+-    lp_url = "https://launchpad.net/api/1.0/~{}/+archive/{}".format(
+-        owner_name, ppa_name
+-    )
++    lp_url = f"https://launchpad.net/api/1.0/~{owner_name}/+archive/{ppa_name}"
+     request = _Request(lp_url, headers={"Accept": "application/json"})
+     lp_page = _urlopen(request)
+     return salt.utils.json.load(lp_page)
+ 
+ 
+-def _reconstruct_ppa_name(owner_name, ppa_name):
+-    """
+-    Stringify PPA name from args.
+-    """
+-    return "ppa:{}/{}".format(owner_name, ppa_name)
+-
+-
+ def _call_apt(args, scope=True, **kwargs):
+     """
+     Call apt* utilities.
+@@ -383,18 +164,6 @@ def _call_apt(args, scope=True, **kwargs):
+     return cmd_ret
+ 
+ 
+-def _warn_software_properties(repo):
+-    """
+-    Warn of missing python-software-properties package.
+-    """
+-    log.warning(
+-        "The 'python-software-properties' package is not installed. "
+-        "For more accurate support of PPA repositories, you should "
+-        "install this package."
+-    )
+-    log.warning("Best guess at ppa format: %s", repo)
+-
+-
+ def normalize_name(name):
+     """
+     Strips the architecture from the specified package name, if necessary.
+@@ -596,7 +365,18 @@ def refresh_db(cache_valid_time=0, failhard=False, **kwargs):
+         except OSError as exp:
+             log.warning("could not stat cache directory due to: %s", exp)
+ 
+-    call = _call_apt(["apt-get", "-q", "update"], scope=False)
++    call = _call_apt(
++        ["apt-get", "-q", "update"],
++        scope=False,
++        timeout=kwargs.get("timeout", __opts__.get("aptpkg_refresh_db_timeout", 30)),
++    )
++    if "Timed out" in call["stdout"]:
++        # In some cases with inconsistent configuration of sources apt-get could
++        # got stuck on calling apt-get update for a long time.
++        # In most cases cleaning up the cache could help,
++        # but update should be triggered again.
++        _call_apt(["apt-get", "-q", "clean"], scope=False)
++        call = _call_apt(["apt-get", "-q", "update"], scope=False)
+     if call["retcode"] != 0:
+         comment = ""
+         if "stderr" in call:
+@@ -624,9 +404,7 @@ def refresh_db(cache_valid_time=0, failhard=False, **kwargs):
+             error_repos.append(ident)
+ 
+     if failhard and error_repos:
+-        raise CommandExecutionError(
+-            "Error getting repos: {}".format(", ".join(error_repos))
+-        )
++        raise CommandExecutionError(f"Error getting repos: {', '.join(error_repos)}")
+ 
+     return ret
+ 
+@@ -852,22 +630,23 @@ def install(
+         )
+     else:
+         pkg_params_items = []
+-        for pkg_source in pkg_params:
+-            if "lowpkg.bin_pkg_info" in __salt__:
++        # we don't need to do the test below for every package in the list.
++        # it either exists or doesn't. test once then loop.
++        if "lowpkg.bin_pkg_info" in __salt__:
++            for pkg_source in pkg_params:
+                 deb_info = __salt__["lowpkg.bin_pkg_info"](pkg_source)
+-            else:
+-                deb_info = None
+-            if deb_info is None:
++                pkg_params_items.append(
++                    [deb_info["name"], pkg_source, deb_info["version"]]
++                )
++        else:
++            for pkg_source in pkg_params:
+                 log.error(
+                     "pkg.install: Unable to get deb information for %s. "
+                     "Version comparisons will be unavailable.",
+                     pkg_source,
+                 )
+                 pkg_params_items.append([pkg_source])
+-            else:
+-                pkg_params_items.append(
+-                    [deb_info["name"], pkg_source, deb_info["version"]]
+-                )
++
+     # Build command prefix
+     cmd_prefix.extend(["apt-get", "-q", "-y"])
+     if kwargs.get("force_yes", False):
+@@ -875,8 +654,14 @@ def install(
+     if "force_conf_new" in kwargs and kwargs["force_conf_new"]:
+         cmd_prefix.extend(["-o", "DPkg::Options::=--force-confnew"])
+     else:
+-        cmd_prefix.extend(["-o", "DPkg::Options::=--force-confold"])
+-        cmd_prefix += ["-o", "DPkg::Options::=--force-confdef"]
++        cmd_prefix.extend(
++            [
++                "-o",
++                "DPkg::Options::=--force-confold",
++                "-o",
++                "DPkg::Options::=--force-confdef",
++            ]
++        )
+     if "install_recommends" in kwargs:
+         if not kwargs["install_recommends"]:
+             cmd_prefix.append("--no-install-recommends")
+@@ -931,12 +716,8 @@ def install(
+                     )
+                     if target is None:
+                         errors.append(
+-                            "No version matching '{}{}' could be found "
+-                            "(available: {})".format(
+-                                pkgname,
+-                                version_num,
+-                                ", ".join(candidates) if candidates else None,
+-                            )
++                            f"No version matching '{pkgname}{version_num}' could be found "
++                            f"(available: {', '.join(candidates) if candidates else None})"
+                         )
+                         continue
+                     else:
+@@ -1401,9 +1182,7 @@ def hold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W0613
+                 ret[target]["comment"] = "Package {} is now being held.".format(target)
+         else:
+             ret[target].update(result=True)
+-            ret[target]["comment"] = "Package {} is already set to be held.".format(
+-                target
+-            )
++            ret[target]["comment"] = f"Package {target} is already set to be held."
+     return ret
+ 
+ 
+@@ -1459,20 +1238,14 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
+         elif salt.utils.data.is_true(state.get("hold", False)):
+             if "test" in __opts__ and __opts__["test"]:
+                 ret[target].update(result=None)
+-                ret[target]["comment"] = "Package {} is set not to be held.".format(
+-                    target
+-                )
++                ret[target]["comment"] = f"Package {target} is set not to be held."
+             else:
+                 result = set_selections(selection={"install": [target]})
+                 ret[target].update(changes=result[target], result=True)
+-                ret[target]["comment"] = "Package {} is no longer being held.".format(
+-                    target
+-                )
++                ret[target]["comment"] = f"Package {target} is no longer being held."
+         else:
+             ret[target].update(result=True)
+-            ret[target]["comment"] = "Package {} is already set not to be held.".format(
+-                target
+-            )
++            ret[target]["comment"] = f"Package {target} is already set not to be held."
+     return ret
+ 
+ 
+@@ -1592,7 +1365,7 @@ def _get_upgradable(dist_upgrade=True, **kwargs):
+     else:
+         cmd.append("upgrade")
+     try:
+-        cmd.extend(["-o", "APT::Default-Release={}".format(kwargs["fromrepo"])])
++        cmd.extend(["-o", f"APT::Default-Release={kwargs['fromrepo']}"])
+     except KeyError:
+         pass
+ 
+@@ -1692,23 +1465,6 @@ def version_cmp(pkg1, pkg2, ignore_epoch=False, **kwargs):
+ 
+     # if we have apt_pkg, this will be quickier this way
+     # and also do not rely on shell.
+-    if HAS_APTPKG:
+-        try:
+-            # the apt_pkg module needs to be manually initialized
+-            apt_pkg.init_system()
+-
+-            # if there is a difference in versions, apt_pkg.version_compare will
+-            # return an int representing the difference in minor versions, or
+-            # 1/-1 if the difference is smaller than minor versions. normalize
+-            # to -1, 0 or 1.
+-            try:
+-                ret = apt_pkg.version_compare(pkg1, pkg2)
+-            except TypeError:
+-                ret = apt_pkg.version_compare(str(pkg1), str(pkg2))
+-            return 1 if ret > 0 else -1 if ret < 0 else 0
+-        except Exception:  # pylint: disable=broad-except
+-            # Try to use shell version in case of errors w/python bindings
+-            pass
+     try:
+         for oper, ret in (("lt", -1), ("eq", 0), ("gt", 1)):
+             cmd = ["dpkg", "--compare-versions", pkg1, oper, pkg2]
+@@ -1722,56 +1478,22 @@ def version_cmp(pkg1, pkg2, ignore_epoch=False, **kwargs):
+     return None
+ 
+ 
+-def _get_opts(line):
+-    """
+-    Return all opts in [] for a repo line
+-    """
+-    get_opts = re.search(r"\[(.*=.*)\]", line)
+-    ret = {
+-        "arch": {"full": "", "value": "", "index": 0},
+-        "signedby": {"full": "", "value": "", "index": 0},
+-    }
+-
+-    if not get_opts:
+-        return ret
+-    opts = get_opts.group(0).strip("[]")
+-    architectures = []
+-    for idx, opt in enumerate(opts.split()):
+-        if opt.startswith("arch"):
+-            architectures.extend(opt.split("=", 1)[1].split(","))
+-            ret["arch"]["full"] = opt
+-            ret["arch"]["value"] = architectures
+-            ret["arch"]["index"] = idx
+-        elif opt.startswith("signed-by"):
+-            ret["signedby"]["full"] = opt
+-            ret["signedby"]["value"] = opt.split("=", 1)[1]
+-            ret["signedby"]["index"] = idx
+-        else:
+-            other_opt = opt.split("=", 1)[0]
+-            ret[other_opt] = {}
+-            ret[other_opt]["full"] = opt
+-            ret[other_opt]["value"] = opt.split("=", 1)[1]
+-            ret[other_opt]["index"] = idx
+-    return ret
+-
+-
+ def _split_repo_str(repo):
+     """
+-    Return APT source entry as a tuple.
++    Return APT source entry as a dictionary
+     """
+-    split = SourceEntry(repo)
+-    if not HAS_APT:
+-        signedby = split.signedby
+-    else:
+-        signedby = _get_opts(line=repo)["signedby"].get("value", "")
+-    return (
+-        split.type,
+-        split.architectures,
+-        split.uri,
+-        split.dist,
+-        split.comps,
+-        signedby,
+-    )
++    entry = SourceEntry(repo)
++    signedby = entry.signedby
++
++    return {
++        "type": entry.type,
++        "architectures": entry.architectures,
++        "uri": entry.uri,
++        "dist": entry.dist,
++        "comps": entry.comps,
++        "signedby": signedby,
++        "trusted": entry.trusted,
++    }
+ 
+ 
+ def _consolidate_repo_sources(sources):
+@@ -1917,52 +1639,46 @@ def list_repos(**kwargs):
+        salt '*' pkg.list_repos disabled=True
+     """
+     repos = {}
+-    if HAS_DEB822:
+-        sources = SourcesList(deb822=True)
+-    else:
+-        sources = SourcesList()
++    sources = SourcesList()
+     for source in sources:
+         if _skip_source(source):
+             continue
+-        if not HAS_APT:
+-            signedby = source.signedby
+-        else:
+-            signedby = _get_opts(line=source.line)["signedby"].get("value", "")
+-        repo = {}
+-        if HAS_DEB822:
+-            try:
+-                signedby = source.section.tags.get("Signed-By", signedby)
+-            except AttributeError:
+-                pass
+-        repo["file"] = source.file
+-        repo_comps = getattr(source, "comps", [])
+-        repo_dists = source.dist.split(" ")
+-        repo["comps"] = repo_comps
+-        repo["disabled"] = source.disabled
+-        repo["enabled"] = not repo[
+-            "disabled"
+-        ]  # This is for compatibility with the other modules
+-        repo["dist"] = repo_dists.pop(0)
+-        repo["type"] = source.type
+-        repo["uri"] = source.uri
+-        if "Types: " in source.line and "\n" in source.line:
+-            repo["line"] = (
+-                f"{source.type} {source.uri} {repo['dist']} {' '.join(repo_comps)}"
+-            )
+-        else:
+-            repo["line"] = source.line.strip()
+-        repo["architectures"] = getattr(source, "architectures", [])
+-        repo["signedby"] = signedby
+-        repos.setdefault(source.uri, []).append(repo)
+-        if len(repo_dists):
+-            for dist in repo_dists:
+-                repo_copy = repo.copy()
+-                repo_copy["dist"] = dist
+-                if "Types: " in source.line and "\n" in source.line:
+-                    repo_copy["line"] = (
+-                        f"{source.type} {source.uri} {repo_copy['dist']} {' '.join(repo_comps)}"
+-                    )
+-                repos[source.uri].append(repo_copy)
++        # deb822 could contain multiple URIs, types and suites
++        # for backward compatibility we need to expand it
++        # to get separate entries for each URI, type and suite
++        for uri in source.uris:
++            for suite in source.suites:
++                for source_type in source.types:
++                    if isinstance(source, Deb822SourceEntry):
++                        compat_source = SourceEntry(
++                            f"{source_type} {uri} {suite} {' '.join(getattr(source, 'comps', []))}"
++                        )
++                        for attr in (
++                            "disabled",
++                            "architectures",
++                            "signedby",
++                            "trusted",
++                        ):
++                            setattr(compat_source, attr, getattr(source, attr))
++                        compat_source_line = str(compat_source)
++                    else:
++                        compat_source_line = source.line.strip()
++                    repo = {
++                        "file": source.file,
++                        "comps": getattr(source, "comps", []),
++                        "disabled": source.disabled,
++                        "enabled": not source.disabled,  # This is for compatibility with the other modules
++                        "dist": suite,
++                        "suites": source.suites,
++                        "type": source_type,
++                        "types": source.types,
++                        "uri": uri,
++                        "uris": source.uris,
++                        "line": compat_source_line,
++                        "architectures": getattr(source, "architectures", []),
++                        "signedby": source.signedby,
++                    }
++                    repos.setdefault(uri, []).append(repo)
+     return repos
+ 
+ 
+@@ -1995,39 +1711,19 @@ def get_repo(repo, **kwargs):
+             auth_info = "{}@".format(ppa_auth)
+             repo = LP_PVT_SRC_FORMAT.format(auth_info, owner_name, ppa_name, dist)
+         else:
+-            if HAS_SOFTWAREPROPERTIES:
+-                try:
+-                    if hasattr(softwareproperties.ppa, "PPAShortcutHandler"):
+-                        repo = softwareproperties.ppa.PPAShortcutHandler(repo).expand(
+-                            dist
+-                        )[0]
+-                    else:
+-                        repo = softwareproperties.ppa.expand_ppa_line(repo, dist)[0]
+-                except NameError as name_error:
+-                    raise CommandExecutionError(
+-                        "Could not find ppa {}: {}".format(repo, name_error)
+-                    )
+-            else:
+-                repo = LP_SRC_FORMAT.format(owner_name, ppa_name, dist)
++            repo = LP_SRC_FORMAT.format(owner_name, ppa_name, dist)
+ 
+     repos = list_repos()
+ 
+     if repos:
+         try:
+-            (
+-                repo_type,
+-                repo_architectures,
+-                repo_uri,
+-                repo_dist,
+-                repo_comps,
+-                repo_signedby,
+-            ) = _split_repo_str(repo)
++            repo_entry = _split_repo_str(repo)
+             if ppa_auth:
+-                uri_match = re.search("(http[s]?://)(.+)", repo_uri)
++                uri_match = re.search("(http[s]?://)(.+)", repo_entry["uri"])
+                 if uri_match:
+                     if not uri_match.group(2).startswith(ppa_auth):
+-                        repo_uri = "{}{}@{}".format(
+-                            uri_match.group(1), ppa_auth, uri_match.group(2)
++                        repo_entry["uri"] = (
++                            f"{uri_match.group(1)}{ppa_auth}@{uri_match.group(2)}"
+                         )
+         except SyntaxError:
+             raise CommandExecutionError(
+@@ -2037,13 +1733,13 @@ def get_repo(repo, **kwargs):
+         for source in repos.values():
+             for sub in source:
+                 if (
+-                    sub["type"] == repo_type
+-                    and sub["uri"] == repo_uri
+-                    and sub["dist"] == repo_dist
++                    sub["type"] == repo_entry["type"]
++                    and sub["uri"].rstrip("/") == repo_entry["uri"].rstrip("/")
++                    and sub["dist"] == repo_entry["dist"]
+                 ):
+-                    if not repo_comps:
++                    if not repo_entry["comps"]:
+                         return sub
+-                    for comp in repo_comps:
++                    for comp in repo_entry["comps"]:
+                         if comp in sub.get("comps", []):
+                             return sub
+     return {}
+@@ -2078,36 +1774,19 @@ def del_repo(repo, **kwargs):
+         # to derive the name.
+         is_ppa = True
+         dist = __grains__["oscodename"]
+-        if not HAS_SOFTWAREPROPERTIES:
+-            _warn_software_properties(repo)
+-            owner_name, ppa_name = repo[4:].split("/")
+-            if "ppa_auth" in kwargs:
+-                auth_info = "{}@".format(kwargs["ppa_auth"])
+-                repo = LP_PVT_SRC_FORMAT.format(auth_info, dist, owner_name, ppa_name)
+-            else:
+-                repo = LP_SRC_FORMAT.format(owner_name, ppa_name, dist)
++        owner_name, ppa_name = repo[4:].split("/")
++        if "ppa_auth" in kwargs:
++            auth_info = f"{kwargs['ppa_auth']}@"
++            repo = LP_PVT_SRC_FORMAT.format(auth_info, dist, owner_name, ppa_name)
+         else:
+-            if hasattr(softwareproperties.ppa, "PPAShortcutHandler"):
+-                repo = softwareproperties.ppa.PPAShortcutHandler(repo).expand(dist)[0]
+-            else:
+-                repo = softwareproperties.ppa.expand_ppa_line(repo, dist)[0]
++            repo = LP_SRC_FORMAT.format(owner_name, ppa_name, dist)
+ 
+-    if HAS_DEB822:
+-        sources = SourcesList(deb822=True)
+-    else:
+-        sources = SourcesList()
++    sources = SourcesList()
+     repos = [s for s in sources.list if not s.invalid]
+     if repos:
+         deleted_from = dict()
+         try:
+-            (
+-                repo_type,
+-                repo_architectures,
+-                repo_uri,
+-                repo_dist,
+-                repo_comps,
+-                repo_signedby,
+-            ) = _split_repo_str(repo)
++            repo_entry = _split_repo_str(repo)
+         except SyntaxError:
+             raise SaltInvocationError(
+                 "Error: repo '{}' not a well formatted definition".format(repo)
+@@ -2115,17 +1794,27 @@ def del_repo(repo, **kwargs):
+ 
+         for source in repos:
+             if (
+-                source.type == repo_type
+-                and source.architectures == repo_architectures
+-                and source.uri == repo_uri
+-                and repo_dist in source.dist
++                repo_entry["type"] in source.type.split()
++                and source.architectures == repo_entry["architectures"]
++                and repo_entry["uri"].rstrip("/")
++                in [uri.rstrip("/") for uri in source.uris]
++                and repo_entry["dist"] in source.suites
+             ):
+-
+                 s_comps = set(source.comps)
+-                r_comps = set(repo_comps)
+-                if s_comps.intersection(r_comps) or (
+-                    s_comps == set() and r_comps == set()
+-                ):
++                r_comps = set(repo_entry["comps"])
++                if s_comps == r_comps:
++                    r_suites = list(source.suites)
++                    r_suites.remove(repo_entry["dist"])
++                    source.suites = r_suites
++                    deleted_from[source.file] = 0
++                    if not source.suites:
++                        try:
++                            sources.remove(source)
++                        except ValueError:
++                            pass
++                    sources.save()
++                    continue
++                if s_comps.intersection(r_comps) or (not s_comps and not r_comps):
+                     deleted_from[source.file] = 0
+                     source.comps = list(s_comps.difference(r_comps))
+                     if not source.comps:
+@@ -2138,15 +1827,27 @@ def del_repo(repo, **kwargs):
+             # measure
+             if (
+                 is_ppa
+-                and repo_type == "deb"
++                and repo_entry["type"] == "deb"
+                 and source.type == "deb-src"
+-                and source.uri == repo_uri
+-                and source.dist == repo_dist
++                and source.uri == repo_entry["uri"]
++                and repo_entry["dist"] in source.suites
+             ):
+ 
+                 s_comps = set(source.comps)
+-                r_comps = set(repo_comps)
+-                if s_comps.intersection(r_comps):
++                r_comps = set(repo_entry["comps"])
++                if s_comps == r_comps:
++                    r_suites = list(source.suites)
++                    r_suites.remove(repo_entry["dist"])
++                    source.suites = r_suites
++                    deleted_from[source.file] = 0
++                    if not source.suites:
++                        try:
++                            sources.remove(source)
++                        except ValueError:
++                            pass
++                    sources.save()
++                    continue
++                if s_comps.intersection(r_comps) or (not s_comps and not r_comps):
+                     deleted_from[source.file] = 0
+                     source.comps = list(s_comps.difference(r_comps))
+                     if not source.comps:
+@@ -2158,6 +1859,8 @@ def del_repo(repo, **kwargs):
+         if deleted_from:
+             ret = ""
+             for source in sources:
++                if source.invalid:
++                    continue
+                 if source.file in deleted_from:
+                     deleted_from[source.file] += 1
+             for repo_file, count in deleted_from.items():
+@@ -2445,9 +2148,7 @@ def add_repo_key(
+         kwargs.update({"stdin": text})
+     elif keyserver:
+         if not keyid:
+-            error_msg = "No keyid or keyid too short for keyserver: {}".format(
+-                keyserver
+-            )
++            error_msg = f"No keyid or keyid too short for keyserver: {keyserver}"
+             raise SaltInvocationError(error_msg)
+ 
+         if not aptkey:
+@@ -2698,30 +2399,20 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
+                     out = _call_apt(cmd, env=env, scope=False, **kwargs)
+                     if out["retcode"]:
+                         raise CommandExecutionError(
+-                            "Unable to add PPA '{}'. '{}' exited with "
+-                            "status {!s}: '{}' ".format(
+-                                repo[4:], cmd, out["retcode"], out["stderr"]
+-                            )
++                            f"Unable to add PPA '{repo[4:]}'. '{cmd}' exited with status {out['retcode']!s}: '{out['stderr']}'"
+                         )
+                     # explicit refresh when a repo is modified.
+                     if refresh:
+                         refresh_db()
+                     return {repo: out}
+             else:
+-                if not HAS_SOFTWAREPROPERTIES:
+-                    _warn_software_properties(repo)
+-                else:
+-                    log.info("Falling back to urllib method for private PPA")
+ 
+                 # fall back to urllib style
+                 try:
+                     owner_name, ppa_name = repo[4:].split("/", 1)
+                 except ValueError:
+                     raise CommandExecutionError(
+-                        "Unable to get PPA info from argument. "
+-                        'Expected format "<PPA_OWNER>/<PPA_NAME>" '
+-                        "(e.g. saltstack/salt) not found.  Received "
+-                        "'{}' instead.".format(repo[4:])
++                        f"Unable to get PPA info from argument. Expected format \"<PPA_OWNER>/<PPA_NAME>\" (e.g. saltstack/salt) not found.  Received '{repo[4:]}' instead."
+                     )
+                 dist = __grains__["oscodename"]
+                 # ppa has a lot of implicit arguments. Make them explicit.
+@@ -2729,8 +2420,10 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
+                 kwargs["dist"] = dist
+                 ppa_auth = ""
+                 if "file" not in kwargs:
+-                    filename = "/etc/apt/sources.list.d/{0}-{1}-{2}.list"
+-                    kwargs["file"] = filename.format(owner_name, ppa_name, dist)
++                    filename = (
++                        f"/etc/apt/sources.list.d/{owner_name}-{ppa_name}-{dist}.list"
++                    )
++                    kwargs["file"] = filename
+                 try:
+                     launchpad_ppa_info = _get_ppa_info_from_launchpad(
+                         owner_name, ppa_name
+@@ -2739,23 +2432,16 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
+                         kwargs["keyid"] = launchpad_ppa_info["signing_key_fingerprint"]
+                     else:
+                         if "keyid" not in kwargs:
+-                            error_str = (
+-                                "Private PPAs require a keyid to be specified: {0}/{1}"
+-                            )
+                             raise CommandExecutionError(
+-                                error_str.format(owner_name, ppa_name)
++                                f"Private PPAs require a keyid to be specified: {owner_name}/{ppa_name}"
+                             )
+                 except HTTPError as exc:
+                     raise CommandExecutionError(
+-                        "Launchpad does not know about {}/{}: {}".format(
+-                            owner_name, ppa_name, exc
+-                        )
++                        f"Launchpad does not know about {owner_name}/{ppa_name}: {exc}"
+                     )
+                 except IndexError as exc:
+                     raise CommandExecutionError(
+-                        "Launchpad knows about {}/{} but did not "
+-                        "return a fingerprint. Please set keyid "
+-                        "manually: {}".format(owner_name, ppa_name, exc)
++                        f"Launchpad knows about {owner_name}/{ppa_name} but did not return a fingerprint. Please set keyid manually: {exc}"
+                     )
+ 
+                 if "keyserver" not in kwargs:
+@@ -2763,15 +2449,13 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
+                 if "ppa_auth" in kwargs:
+                     if not launchpad_ppa_info["private"]:
+                         raise CommandExecutionError(
+-                            "PPA is not private but auth credentials passed: {}".format(
+-                                repo
+-                            )
++                            f"PPA is not private but auth credentials passed: {repo}"
+                         )
+                 # assign the new repo format to the "repo" variable
+                 # so we can fall through to the "normal" mechanism
+                 # here.
+                 if "ppa_auth" in kwargs:
+-                    ppa_auth = "{}@".format(kwargs["ppa_auth"])
++                    ppa_auth = f"{kwargs['ppa_auth']}@"
+                     repo = LP_PVT_SRC_FORMAT.format(
+                         ppa_auth, owner_name, ppa_name, dist
+                     )
+@@ -2782,10 +2466,7 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
+                 'cannot parse "ppa:" style repo definitions: {}'.format(repo)
+             )
+ 
+-    if HAS_DEB822:
+-        sources = SourcesList(deb822=True)
+-    else:
+-        sources = SourcesList()
++    sources = SourcesList()
+     if kwargs.get("consolidate", False):
+         # attempt to de-dup and consolidate all sources
+         # down to entries in sources.list
+@@ -2802,40 +2483,29 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
+ 
+     repos = []
+     for source in sources:
+-        if HAS_APT and not HAS_DEB822:
+-            _, invalid, _, _ = _invalid(source.line)
+-            if not invalid:
+-                repos.append(source)
+-        else:
+-            if HAS_DEB822 and (
+-                source.types == [""] or not bool(source.types) or not source.type
+-            ):
+-                # most probably invalid or comment line
++        if isinstance(source, Deb822SourceEntry):
++            if source.types == [""] or not bool(source.types) or not source.type:
+                 continue
+-            repos.append(source)
++        else:
++            _, invalid, _, _ = _invalid(source.line)
++            if invalid:
++                continue
++        repos.append(source)
+ 
+     mod_source = None
+     try:
+-        (
+-            repo_type,
+-            repo_architectures,
+-            repo_uri,
+-            repo_dist,
+-            repo_comps,
+-            repo_signedby,
+-        ) = _split_repo_str(repo)
++        repo_entry = _split_repo_str(repo)
+     except SyntaxError:
+         raise SyntaxError(
+             "Error: repo '{}' not a well formatted definition".format(repo)
+         )
+ 
+-    full_comp_list = {comp.strip() for comp in repo_comps}
++    full_comp_list = [comp.strip() for comp in repo_entry["comps"]]
+     no_proxy = __salt__["config.option"]("no_proxy")
+ 
+-    kwargs["signedby"] = pathlib.Path(repo_signedby) if repo_signedby else ""
+-
+-    if not aptkey and not kwargs["signedby"]:
+-        raise SaltInvocationError("missing 'signedby' option when apt-key is missing")
++    kwargs["signedby"] = (
++        pathlib.Path(repo_entry["signedby"]) if repo_entry["signedby"] else ""
++    )
+ 
+     if "keyid" in kwargs:
+         keyid = kwargs.pop("keyid", None)
+@@ -2902,9 +2572,7 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
+                             ret = _call_apt(cmd, scope=False, **kwargs)
+                             if ret["retcode"] != 0:
+                                 raise CommandExecutionError(
+-                                    "Error: key retrieval failed: {}".format(
+-                                        ret["stdout"]
+-                                    )
++                                    f"Error: key retrieval failed: {ret['stdout']}"
+                                 )
+ 
+     elif "key_url" in kwargs:
+@@ -2948,14 +2616,16 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
+ 
+     if "comps" in kwargs:
+         kwargs["comps"] = [comp.strip() for comp in kwargs["comps"].split(",")]
+-        full_comp_list |= set(kwargs["comps"])
++        for comp in kwargs["comps"]:
++            if comp not in full_comp_list:
++                full_comp_list.append(comp)
+     else:
+         kwargs["comps"] = list(full_comp_list)
+ 
+     if "architectures" in kwargs:
+         kwargs["architectures"] = kwargs["architectures"].split(",")
+     else:
+-        kwargs["architectures"] = repo_architectures
++        kwargs["architectures"] = repo_entry["architectures"]
+ 
+     if "disabled" in kwargs:
+         kwargs["disabled"] = salt.utils.data.is_true(kwargs["disabled"])
+@@ -2970,13 +2640,13 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
+         # and the resulting source line.  The idea here is to ensure
+         # we are not returning bogus data because the source line
+         # has already been modified on a previous run.
+-        apt_source_dists = apt_source.dist.split(" ")
+         repo_matches = (
+-            apt_source.type == repo_type
+-            and apt_source.uri.rstrip("/") == repo_uri.rstrip("/")
+-            and repo_dist in apt_source_dists
++            repo_entry["type"] in apt_source.type.split()
++            and repo_entry["uri"].rstrip("/")
++            in [uri.rstrip("/") for uri in apt_source.uris]
++            and repo_entry["dist"] in apt_source.suites
+         )
+-        kw_matches = apt_source.dist == kw_dist and apt_source.type == kw_type
++        kw_matches = kw_dist in apt_source.suites and kw_type in apt_source.type.split()
+ 
+         if repo_matches or kw_matches:
+             for comp in full_comp_list:
+@@ -2992,72 +2662,63 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
+     if "comments" in kwargs:
+         kwargs["comments"] = salt.utils.pkg.deb.combine_comments(kwargs["comments"])
+ 
++    repo_source_entry = SourceEntry(repo)
+     if not mod_source:
++        if not aptkey and not (
++            kwargs["signedby"] or string_to_bool(kwargs.get("trusted", "no"))
++        ):
++            raise SaltInvocationError(
++                "missing 'signedby' or 'trusted' option when apt-key is missing"
++            )
++
+         apt_source_file = kwargs.get("file")
+-        if not apt_source_file:
+-            raise SaltInvocationError("missing 'file' argument when defining a new repository")
+-        if HAS_DEB822 and not apt_source_file.endswith(".list"):
+-            section = _deb822.Section("")
+-            section["Types"] = repo_type
+-            section["URIs"] = repo_uri
+-            section["Suites"] = repo_dist
+-            section["Components"] = " ".join(repo_comps)
+-            if kwargs.get("trusted") == True or kwargs.get("Trusted") == True:
++
++        if apt_source_file and apt_source_file.endswith(".sources"):
++            section = Deb822Section("")
++            section["Types"] = repo_entry["type"]
++            section["URIs"] = repo_entry["uri"]
++            section["Suites"] = repo_entry["dist"]
++            section["Components"] = " ".join(repo_entry["comps"])
++            trusted_kwargs = kwargs.get("trusted") is True or kwargs.get("Trusted") is True
++            if trusted_kwargs or ("trusted" not in kwargs and repo_entry["trusted"] is True):
+                 section["Trusted"] = "yes"
+             mod_source = Deb822SourceEntry(section, apt_source_file)
+         else:
+-            mod_source = SourceEntry(repo)
++            mod_source = SourceEntry(repo, apt_source_file)
+         if "comments" in kwargs:
+             mod_source.comment = kwargs["comments"]
+         sources.list.append(mod_source)
+     elif "comments" in kwargs:
+         mod_source.comment = kwargs["comments"]
+ 
+-    if HAS_APT:
+-        # workaround until python3-apt supports signedby
+-        if str(mod_source) != str(SourceEntry(repo)) and "signed-by" in str(mod_source):
+-            rline = SourceEntry(repo)
+-            mod_source.line = rline.line
++    if not isinstance(mod_source, Deb822SourceEntry):
++        mod_source.line = repo_source_entry.line
++        if not mod_source.line.endswith("\n"):
++            mod_source.line = mod_source.line + "\n"
+ 
+-    if not mod_source.line.endswith("\n"):
+-        mod_source.line = mod_source.line + "\n"
++    if not kwargs["architectures"] and not mod_source.architectures:
++        kwargs.pop("architectures")
+ 
+     for key in kwargs:
+-        if key in _MODIFY_OK and hasattr(mod_source, key):
++        if (
++            (isinstance(mod_source, Deb822SourceEntry) and key in _MODIFY_OK)
++            or key in _MODIFY_OK_LEGACY
++        ) and hasattr(mod_source, key):
+             setattr(mod_source, key, kwargs[key])
+ 
+-    if mod_source.uri != repo_uri:
+-        mod_source.uri = repo_uri
+-        if not HAS_DEB822:
+-            mod_source.line = mod_source.str()
++    if (
++        not isinstance(mod_source, Deb822SourceEntry)
++        and mod_source.uri != repo_entry["uri"]
++    ):
++        mod_source.uri = repo_entry["uri"]
++        mod_source.line = str(mod_source)
+ 
+     sources.save()
+     # on changes, explicitly refresh
+     if refresh:
+         refresh_db()
+ 
+-    if not HAS_APT:
+-        signedby = mod_source.signedby
+-    else:
+-        signedby = _get_opts(repo)["signedby"].get("value", "")
+-
+-    repo_source_line = mod_source.line
+-    if "Types: " in repo_source_line and "\n" in repo_source_line:
+-        repo_source_line = f"{mod_source.type} {mod_source.uri} {repo_dist} {' '.join(mod_source.comps)}"
+-
+-    return {
+-        repo: {
+-            "architectures": getattr(mod_source, "architectures", []),
+-            "dist": mod_source.dist,
+-            "comps": mod_source.comps,
+-            "disabled": mod_source.disabled,
+-            "file": mod_source.file,
+-            "type": mod_source.type,
+-            "uri": mod_source.uri,
+-            "line": repo_source_line,
+-            "signedby": signedby,
+-        }
+-    }
++    return {repo: get_repo(repo)}
+ 
+ 
+ def file_list(*packages, **kwargs):
+@@ -3115,19 +2776,12 @@ def _expand_repo_def(os_name, os_codename=None, **kwargs):
+             auth_info = "{}@".format(kwargs["ppa_auth"])
+             repo = LP_PVT_SRC_FORMAT.format(auth_info, owner_name, ppa_name, dist)
+         else:
+-            if HAS_SOFTWAREPROPERTIES:
+-                if hasattr(softwareproperties.ppa, "PPAShortcutHandler"):
+-                    repo = softwareproperties.ppa.PPAShortcutHandler(repo).expand(dist)[
+-                        0
+-                    ]
+-                else:
+-                    repo = softwareproperties.ppa.expand_ppa_line(repo, dist)[0]
+-            else:
+-                repo = LP_SRC_FORMAT.format(owner_name, ppa_name, dist)
++            repo = LP_SRC_FORMAT.format(owner_name, ppa_name, dist)
+ 
+         if "file" not in kwargs:
+-            filename = "/etc/apt/sources.list.d/{0}-{1}-{2}.list"
+-            kwargs["file"] = filename.format(owner_name, ppa_name, dist)
++            kwargs["file"] = (
++                f"/etc/apt/sources.list.d/{owner_name}-{ppa_name}-{dist}.list"
++            )
+ 
+     source_entry = SourceEntry(repo)
+     for list_args in ("architectures", "comps"):
+@@ -3135,66 +2789,44 @@ def _expand_repo_def(os_name, os_codename=None, **kwargs):
+             kwargs[list_args] = [
+                 kwarg.strip() for kwarg in kwargs[list_args].split(",")
+             ]
+-    for kwarg in _MODIFY_OK:
++    for kwarg in _MODIFY_OK_LEGACY:
+         if kwarg in kwargs:
+             setattr(source_entry, kwarg, kwargs[kwarg])
+ 
+-    if HAS_DEB822:
+-        source_list = SourcesList(deb822=True)
+-    else:
+-        source_list = SourcesList()
+-    kwargs = {}
+-    if not HAS_APT:
+-        signedby = source_entry.signedby
+-        kwargs["signedby"] = signedby
+-    else:
+-        signedby = _get_opts(repo)["signedby"].get("value", "")
++    source_list = SourcesList()
++
++    new_kwargs = {}
++    for arg in ("file", "suites", "trusted", "types", "uris"):
++        if arg in kwargs:
++            new_kwargs[arg] = kwargs[arg]
++
++    signedby = source_entry.signedby
++    new_kwargs["signedby"] = signedby
+ 
+     _source_entry = source_list.add(
+         type=source_entry.type,
+         uri=source_entry.uri,
+         dist=source_entry.dist,
+-        orig_comps=getattr(source_entry, "comps", []),
+-        architectures=getattr(source_entry, "architectures", []),
+-        **kwargs,
++        orig_comps=source_entry.comps,
++        architectures=source_entry.architectures,
++        **new_kwargs,
+     )
+-    if hasattr(_source_entry, "set_enabled"):
+-        _source_entry.set_enabled(not source_entry.disabled)
+-    else:
+-        _source_entry.disabled = source_entry.disabled
++    _source_entry.disabled = source_entry.disabled
++    if not isinstance(_source_entry, Deb822SourceEntry):
+         _source_entry.line = _source_entry.repo_line()
+ 
+     sanitized["file"] = _source_entry.file
+-    sanitized["comps"] = getattr(_source_entry, "comps", [])
++    sanitized["comps"] = _source_entry.comps
+     sanitized["disabled"] = _source_entry.disabled
+     sanitized["dist"] = _source_entry.dist
++    sanitized["suites"] = _source_entry.suites
+     sanitized["type"] = _source_entry.type
++    sanitized["types"] = _source_entry.types
+     sanitized["uri"] = _source_entry.uri
+-    sanitized["line"] = getattr(_source_entry, "line", "").strip()
+-    sanitized["architectures"] = getattr(_source_entry, "architectures", [])
++    sanitized["uris"] = _source_entry.uris
++    sanitized["line"] = str(_source_entry)
++    sanitized["architectures"] = _source_entry.architectures
+     sanitized["signedby"] = signedby
+-    if HAS_APT and signedby:
+-        # python3-apt does not supported the signed-by opt currently.
+-        # creating the line with all opts including signed-by
+-        if signedby not in sanitized["line"]:
+-            line = sanitized["line"].split()
+-            repo_opts = _get_opts(repo)
+-            opts_order = [
+-                opt_type
+-                for opt_type, opt_def in repo_opts.items()
+-                if opt_def["full"] != ""
+-            ]
+-            for opt in repo_opts:
+-                if "index" in repo_opts[opt]:
+-                    idx = repo_opts[opt]["index"]
+-                    opts_order[idx] = repo_opts[opt]["full"]
+-
+-            opts = "[" + " ".join(opts_order) + "]"
+-            if line[1].startswith("["):
+-                line[1] = opts
+-            else:
+-                line.insert(1, opts)
+-            sanitized["line"] = " ".join(line)
+ 
+     return sanitized
+ 
+@@ -3363,9 +2995,7 @@ def set_selections(path=None, selection=None, clear=False, saltenv="base"):
+         valid_states = ("install", "hold", "deinstall", "purge")
+         bad_states = [x for x in selection if x not in valid_states]
+         if bad_states:
+-            raise SaltInvocationError(
+-                "Invalid state(s): {}".format(", ".join(bad_states))
+-            )
++            raise SaltInvocationError(f"Invalid state(s): {', '.join(bad_states)}")
+ 
+         if clear:
+             cmd = ["dpkg", "--clear-selections"]
+@@ -3688,3 +3318,31 @@ def services_need_restart(**kwargs):
+         services.add(service)
+ 
+     return list(services)
++
++
++def which(path):
++    """
++    Displays which package installed a specific file
++
++    CLI Examples:
++
++    .. code-block:: bash
++
++        salt * pkg.which <file name>
++    """
++    filepath = pathlib.Path(path)
++    cmd = ["dpkg"]
++    if filepath.is_absolute():
++        if filepath.exists():
++            cmd.extend(["-S", str(filepath)])
++        else:
++            log.debug("%s does not exist", filepath)
++            return False
++    else:
++        log.debug("%s is not absolute path", filepath)
++        return False
++    cmd_ret = _call_apt(cmd)
++    if "no path found matching pattern" in cmd_ret["stdout"]:
++        return None
++    pkg = cmd_ret["stdout"].split(":")[0]
++    return pkg
+diff --git a/salt/states/pkgrepo.py b/salt/states/pkgrepo.py
+index 4ef5fd9c2f..cbaf5ef493 100644
+--- a/salt/states/pkgrepo.py
++++ b/salt/states/pkgrepo.py
+@@ -416,7 +416,8 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
+             return ret
+ 
+     repo = name
+-    if __grains__["os"] in ("Ubuntu", "Mint"):
++
++    if __grains__["os_family"] == "Debian":
+         if ppa is not None:
+             # overload the name/repo value for PPAs cleanly
+             # this allows us to have one code-path for PPAs
+@@ -552,6 +553,23 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
+             ret["comment"] = f"Package repo '{name}' already configured"
+             return ret
+ 
++    if __grains__["os_family"] == "Debian":
++        if (
++            "uri" not in kwargs
++            and "uri" in sanitizedkwargs
++            and "uri" in pre
++            and pre["uri"] != sanitizedkwargs["uri"]
++        ):
++            kwargs["uri"] = sanitizedkwargs["uri"]
++        if (
++            "uris" not in kwargs
++            and "uris" in sanitizedkwargs
++            and "uris" in pre
++            and sanitizedkwargs["uris"]
++            and sanitizedkwargs["uris"][0] not in pre["uris"]
++        ):
++            kwargs["uris"] = sanitizedkwargs["uris"]
++
+     if __opts__["test"]:
+         ret["comment"] = (
+             "Package repo '{}' would be configured. This may cause pkg "
+@@ -624,6 +642,12 @@ def absent(name, **kwargs):
+         The name of the package repo, as it would be referred to when running
+         the regular package manager commands.
+ 
++    .. note::
++        On apt-based systems this must be the complete source entry. For
++        example, if you include ``[arch=amd64]``, and a repo matching the
++        specified URI, dist, etc. exists _without_ an architecture, then no
++        changes will be made and the state will report a ``True`` result.
++
+     **FEDORA/REDHAT-SPECIFIC OPTIONS**
+ 
+     copr
+@@ -706,6 +730,23 @@ def absent(name, **kwargs):
+         ret["comment"] = f"Failed to configure repo '{name}': {exc}"
+         return ret
+ 
++    if repo and (
++        __grains__["os_family"].lower() == "debian"
++        or __opts__.get("providers", {}).get("pkg") == "aptpkg"
++    ):
++        # On Debian/Ubuntu, pkg.get_repo will return a match for the repo
++        # even if the architectures do not match. However, changing get_repo
++        # breaks idempotency for pkgrepo.managed states. So, compare the
++        # architectures of the matched repo to the architectures specified in
++        # the repo string passed to this state. If the architectures do not
++        # match, then invalidate the match by setting repo to an empty dict.
++        import salt.modules.aptpkg
++
++        if set(salt.modules.aptpkg._split_repo_str(stripname)["architectures"]) != set(
++            repo["architectures"]
++        ):
++            repo = {}
++
+     if not repo:
+         ret["comment"] = f"Package repo {name} is absent"
+         ret["result"] = True
+diff --git a/salt/utils/pkg/deb.py b/salt/utils/pkg/deb.py
+index c8bfa8ae20..cce30fb28e 100644
+--- a/salt/utils/pkg/deb.py
++++ b/salt/utils/pkg/deb.py
+@@ -2,6 +2,807 @@
+ Common functions for working with deb packages
+ """
+ 
++import logging
++import os
++import re
++from collections import OrderedDict
++
++from salt.exceptions import SaltInvocationError
++import salt.utils.files
++
++log = logging.getLogger(__name__)
++
++
++_APT_SOURCES_LIST = "/etc/apt/sources.list"
++_APT_SOURCES_PARTSDIR = "/etc/apt/sources.list.d/"
++
++
++def string_to_bool(s):
++    """
++    Convert string representation of bool values to bool
++    """
++    if isinstance(s, bool):
++        return s
++    s = s.lower()
++    if s in ("no", "false", "without", "off", "disable"):
++        return False
++    elif s in ("yes", "true", "with", "on", "enable"):
++        return True
++    raise ValueError(f"Unable to convert to boolean: {s}")
++
++
++class Deb822Section:
++    """
++    A deb822 section representation of single entry,
++    which could contain comments.
++    """
++
++    def __init__(self, section):
++        """
++        Init new deb822 section object
++        """
++        if isinstance(section, Deb822Section):
++            self.tags = OrderedDict(section.tags)
++            self.header = section.header
++            self.footer = section.footer
++        else:
++            self.tags, self.header, self.footer = self._parse_section_string(section)
++        self._tag_map = {k.lower(): k for k in self.tags}
++
++    @staticmethod
++    def _parse_section_string(section_string):
++        """
++        Parse section string to comments and tags
++        """
++        header = []
++        footer = []
++        raw_data = []
++        tag_re = re.compile(r"\A(\S+):\s*(\S.*|)")
++        tags = OrderedDict()
++
++        for line in section_string.splitlines():
++            if line.startswith("#"):
++                if raw_data:
++                    footer.append(line)
++                else:
++                    header.append(line)
++            else:
++                raw_data.append(line)
++
++        tag = None
++        value = None
++        for line in raw_data:
++            match = tag_re.match(line)
++            if match:
++                if tag is not None:
++                    # Store previous found tag,
++                    # as the values could contain multiple lines
++                    tags[tag] = value.strip()
++                tag, value = match.groups()
++            elif line == "" and tag is not None:
++                tags[tag] = value.strip()
++            else:
++                value = f"{value}\n{line}"
++        if tag is not None:
++            tags[tag] = value.strip()
++
++        return tags, header, footer
++
++    def __getitem__(self, key):
++        """
++        Get the value of a tag
++        """
++        return self.tags[self._tag_map.get(key.lower(), key)]
++
++    def __delitem__(self, key):
++        """
++        Delete the tag
++        """
++        _lc_key = key.lower()
++        del self.tags[self._tag_map.get(_lc_key, key)]
++        del self._tag_map[_lc_key]
++
++    def __setitem__(self, key, val):
++        """
++        Set the value of the tag
++        """
++        _lc_key = key.lower()
++        if _lc_key not in self._tag_map:
++            self._tag_map[_lc_key] = key
++        self.tags[key] = val
++
++    def __bool__(self):
++        """
++        Represent as True if the section has any tag
++        """
++        return bool(self.tags)
++
++    def get(self, key, default=None):
++        """
++        Get the value of a tag or return default
++        """
++        try:
++            return self[key]
++        except KeyError:
++            return default
++
++    def __str__(self):
++        """
++        Return the string representation of the section
++        """
++        return (
++            "\n".join(self.header)
++            + ("\n" if self.header else "")
++            + "".join(
++                (f"{k}: {v}\n" if str(v) != "" else "") for k, v in self.tags.items()
++            )
++            + "\n".join(self.footer)
++            + ("\n" if self.footer else "")
++        )
++
++
++class Deb822SourceEntry:
++    """
++    Source entry in deb822 format
++    """
++
++    _properties = {
++        "architectures": {"key": "Architectures", "multi": True},
++        "types": {"key": "Types", "multi": True},
++        "type": {"key": "Types", "multi": False, "deprecated": True},
++        "uris": {"key": "URIs", "multi": True},
++        "uri": {"key": "URIs", "multi": False, "deprecated": True},
++        "suites": {"key": "Suites", "multi": True},
++        "dist": {"key": "Suites", "multi": False, "deprecated": True},
++        "comps": {"key": "Components", "multi": True},
++        "signedby": {"key": "Signed-By", "multi": False},
++    }
++
++    def __init__(
++        self,
++        section,
++        file,
++        list=None,
++    ):
++        if section is None:
++            self.section = Deb822Section("")
++        elif isinstance(section, str):
++            self.section = Deb822Section(section)
++        else:
++            self.section = section
++
++        self._line = str(self.section)
++        self.file = file
++
++    def __getattr__(self, name):
++        """
++        Get the values to the section for specified keys
++        """
++        if name in self._properties:
++            if self._properties[name]["multi"]:
++                return SourceEntry.split_source_line(
++                    self.section.get(self._properties[name]["key"], "")
++                )
++            else:
++                return self.section.get(self._properties[name]["key"], None)
++
++    def __setattr__(self, name, value):
++        """
++        Pass the values to the section for specified keys
++        """
++        if name not in self._properties:
++            return super().__setattr__(name, value)
++
++        key = self._properties[name]["key"]
++        if value is None:
++            del self.section[key]
++        else:
++            if key == "Signed-By":
++                value = str(value)
++            self.section[key] = (
++                " ".join(value) if self._properties[name]["multi"] else value
++            )
++
++    def __eq__(self, other):
++        """
++        Equal operator for deb822 source entries
++        """
++        return (
++            self.disabled == other.disabled
++            and self.type == other.type
++            and set([uri.rstrip("/") for uri in self.uris])
++            == set([uri.rstrip("/") for uri in other.uris])
++            and self.dist == other.dist
++            and self.comps == other.comps
++        )
++
++    @property
++    def comment(self):
++        """
++        Returns the header of the section
++        """
++        return "\n".join(self.section.header)
++
++    @comment.setter
++    def comment(self, comment):
++        """
++        Sets the header of the section
++        """
++        comments = comment.splitlines()
++        if not all(x.startswith("#") for x in comments):
++            comments = [f"#{x}" for x in comments]
++        self.section.header = comments
++
++    @property
++    def trusted(self):
++        """
++        Return the value of the Trusted field
++        """
++        try:
++            return string_to_bool(self.section["Trusted"])
++        except KeyError:
++            return None
++
++    @trusted.setter
++    def trusted(self, value):
++        if isinstance(value, bool):
++            self.section["Trusted"] = "yes" if value else "no"
++        elif isinstance(value, int) and value in (0, 1):
++            self.section["Trusted"] = "yes" if value == 1 else "no"
++        elif isinstance(value, str):
++            self.section["Trusted"] = "yes" if string_to_bool(value) else "no"
++        else:
++            try:
++                del self.section["Trusted"]
++            except KeyError:
++                pass
++
++    @property
++    def disabled(self):
++        """
++        Return True if the source is enabled
++        """
++        return not string_to_bool(self.section.get("Enabled", "yes"))
++
++    @disabled.setter
++    def disabled(self, value):
++        if value:
++            self.section["Enabled"] = "no"
++        else:
++            try:
++                del self.section["Enabled"]
++            except KeyError:
++                pass
++
++    @property
++    def invalid(self):
++        """
++        Return True if the source doesn't have proper attributes
++        """
++        return not self.section
++
++    @property
++    def line(self):
++        """
++        Return the original string representation of the source entry
++        """
++        return self._line
++
++    def __str__(self):
++        """
++        Return the string representation of the entry
++        """
++        return str(self.section).strip()
++
++
++class SourceEntry:
++    """
++    Distinct sources.list entry
++    """
++
++    def __init__(self, line, file=None):
++        self.invalid = False
++        self.disabled = False  # identified as disabled if commented
++        self.type = ""  # type of the source (deb, deb-src)
++        self.architectures = []
++        self._signedby = ""
++        self._trusted = None
++        self.uri = ""
++        self.dist = ""  # distribution name
++        self.comps = []  # list of available componetns (or empty)
++        self.comment = ""  # comment (optional)
++        self.line = line  # the original sources.list entry
++        if file is None:
++            file = _APT_SOURCES_LIST
++        if file.endswith(".sources"):
++            raise ValueError("Classic SourceEntry cannot be written to .sources file")
++        self.file = file  # the file that the entry is located in
++        self.parse(line)
++        self.children = []
++
++    def __eq__(self, other):
++        """
++        Equal operator for two classic sources.list entries
++        """
++        return (
++            self.disabled == other.disabled
++            and self.type == other.type
++            and self.uri.rstrip("/") == other.uri.rstrip("/")
++            and self.dist == other.dist
++            and self.comps == other.comps
++        )
++
++    @staticmethod
++    def split_source_line(line):
++        """
++        Splits the entries of sources.list format
++        """
++        line = line.strip()
++        pieces = []
++        tmp = ""
++        # we are inside a [..] block
++        p_found = False
++        space_found = False
++        for c in line:
++            if c == "[":
++                if space_found:
++                    space_found = False
++                    p_found = True
++                    pieces.append(tmp)
++                    tmp = c
++                else:
++                    p_found = True
++                    tmp += c
++            elif c == "]":
++                p_found = False
++                tmp += c
++            elif space_found and not c.isspace():
++                # we skip one or more space
++                space_found = False
++                pieces.append(tmp)
++                tmp = c
++            elif c.isspace() and not p_found:
++                # found a whitespace
++                space_found = True
++            else:
++                tmp += c
++        # append last piece
++        if len(tmp) > 0:
++            pieces.append(tmp)
++        return pieces
++
++    def parse(self, line):
++        """
++        Parse lines from sources files
++        """
++        self.disabled, self.invalid, self.comment, repo_line = _invalid(line)
++        if self.invalid:
++            return False
++        if repo_line[1].startswith("["):
++            repo_line = [x for x in (line.strip("[]") for line in repo_line) if x]
++            opts = _get_opts(self.line)
++            if "arch" in opts:
++                self.architectures.extend(opts["arch"]["value"])
++            if "signedby" in opts:
++                self.signedby = opts["signedby"]["value"]
++            if "trusted" in opts:
++                self.trusted = opts["trusted"]["value"]
++            for opt in opts.values():
++                opt = opt["full"]
++                if opt:
++                    try:
++                        repo_line.pop(repo_line.index(opt))
++                    except ValueError:
++                        repo_line.pop(repo_line.index(f"[{opt}]"))
++        if len(repo_line) < 3:
++            raise SaltInvocationError(f"Invalid repository definition: {' '.join(repo_line)}")
++        self.type = repo_line[0]
++        self.uri = repo_line[1]
++        self.dist = repo_line[2]
++        self.comps = repo_line[3:]
++        return True
++
++    def __str__(self):
++        """
++        Return string representation
++        """
++        return self.repo_line().strip()
++
++    def repo_line(self):
++        """
++        Return the line of the entry for the sources file
++        """
++        repo_line = []
++        if self.invalid:
++            return self.line
++        if self.disabled:
++            repo_line.append("#")
++
++        repo_line.append(self.type)
++        opts = _get_opts(self.line)
++        if self.architectures:
++            if "arch" not in opts:
++                opts["arch"] = {}
++            opts["arch"]["full"] = f"arch={','.join(self.architectures)}"
++            opts["arch"]["value"] = self.architectures
++        if self.signedby:
++            if "signedby" not in opts:
++                opts["signedby"] = {}
++            opts["signedby"]["full"] = f"signed-by={self.signedby}"
++            opts["signedby"]["value"] = self.signedby
++        if self._trusted:
++            if "trusted" not in opts:
++                opts["trusted"] = {}
++            opts["trusted"]["value"] = "yes" if self._trusted else "no"
++            opts["trusted"]["full"] = f"trusted={opts['trusted']['value']}"
++        if "trusted" in opts and opts["trusted"]["value"] == "no":
++            del opts["trusted"]
++
++        ordered_opts = []
++        for opt in opts.values():
++            if opt["full"] != "":
++                ordered_opts.append(opt["full"])
++
++        if ordered_opts:
++            repo_line.append(f"[{' '.join(ordered_opts)}]")
++
++        repo_line += [self.uri, self.dist, " ".join(self.comps)]
++        if self.comment:
++            repo_line.append(f"#{self.comment}")
++        return " ".join(repo_line) + "\n"
++
++    @property
++    def types(self):
++        """
++        Deb822 compatible attribute for the type
++        """
++        return [self.type]
++
++    @property
++    def uris(self):
++        """
++        Deb822 compatible attribute for the uri
++        """
++        return [self.uri]
++
++    @property
++    def suites(self):
++        """
++        Deb822 compatible attribute for the suite
++        """
++        if self.dist:
++            return [self.dist]
++        return []
++
++    @suites.setter
++    def suites(self, suites):
++        """
++        Deb822 compatible setter for the suite
++        """
++        if len(suites) > 1:
++            raise ValueError("Only one suite is possible for non deb822 source entry")
++        if suites:
++            self.dist = str(suites[0])
++            assert self.dist == suites[0]
++        else:
++            self.dist = ""
++            assert self.dist == ""
++
++    @property
++    def signedby(self):
++        """
++        Deb822 compatible attribute for the signedby
++        """
++        return self._signedby
++
++    @signedby.setter
++    def signedby(self, signedby):
++        """
++        Deb822 compatible setter for the signedy
++        """
++        self._signedby = str(signedby)
++
++    @property
++    def trusted(self):
++        """
++        Deb822 compatible attribute for the trusted
++        """
++        return self._trusted
++
++    @trusted.setter
++    def trusted(self, trusted):
++        """
++        Deb822 compatible setter for the trusted
++        """
++        if isinstance(trusted, bool):
++            self._trusted = trusted
++        elif isinstance(trusted, int) and trusted in (0, 1):
++            self._trusted = trusted == 1
++        elif isinstance(trusted, str):
++            self._trusted = string_to_bool(trusted)
++        else:
++            self._trusted = None
++
++
++class SourcesList:
++    """
++    Represents the full sources.list + sources.list.d files
++    including deb822 .sources files
++    """
++
++    def __init__(
++        self,
++    ):
++        self.list = []  # the actual SourceEntries Type
++        self.refresh()
++
++    def refresh(self):
++        """update the list of known entries"""
++        self.list = []
++        # read sources.list
++        file = _APT_SOURCES_LIST
++        if os.path.isfile(file):
++            self.load(file)
++        # read sources.list.d
++        partsdir = _APT_SOURCES_PARTSDIR
++        if os.path.isdir(partsdir):
++            for file in os.listdir(partsdir):
++                if file.endswith(".sources") or file.endswith(".list"):
++                    self.load(os.path.join(partsdir, file))
++
++    def __iter__(self):
++        """
++        Iterate over self.list with SourceEntry elements
++        """
++        yield from self.list
++
++    def add(
++        self,
++        type,
++        uri,
++        dist,
++        orig_comps,
++        comment="",
++        pos=-1,
++        file=None,
++        architectures=None,
++        signedby="",
++        suites=None,
++        trusted=False,
++        types=None,
++        parent=None,
++        uris=None,
++    ):
++        """
++        Add a new source to the sources.list.
++        The method will search for existing matching repos and will try to
++        reuse them as far as possible
++        """
++
++        type = type.strip()
++        disabled = type.startswith("#")
++        if disabled:
++            type = type[1:].lstrip()
++        if architectures is None:
++            architectures = []
++        # create a working copy of the component list so that
++        # we can modify it later
++        comps = orig_comps[:]
++
++        new_entry = None
++        if file is None:
++            file = _APT_SOURCES_LIST
++        if file.endswith(".sources"):
++            new_entry = Deb822SourceEntry(None, file=file, list=self)
++            if parent:
++                parent = getattr(parent, "parent", parent)
++                assert isinstance(parent, Deb822SourceEntry)
++                for k in parent.section.tags:
++                    new_entry.section[k] = parent.section[k]
++            new_entry.types = types if types and isinstance(types, list) else [type]
++            new_entry.uris = uris if uris and isinstance(uris, list) else [uri]
++            new_entry.suites = suites if suites and isinstance(suites, list) else [dist]
++            new_entry.comps = comps
++            if architectures:
++                new_entry.architectures = list(architectures)
++            new_entry.section.header = (
++                comment if isinstance(comment, list) else [comment]
++            )
++            new_entry.disabled = disabled
++            if signedby:
++                new_entry.signedby = signedby
++            if trusted is not False:
++                new_entry.trusted = trusted
++        else:
++            ext_attrs = ""
++            if architectures:
++                ext_attrs = f"arch={','.join(architectures)}"
++            if signedby:
++                if ext_attrs:
++                    ext_attrs = f"{ext_attrs} "
++                ext_attrs = f"{ext_attrs}signed-by={signedby}"
++            if trusted:
++                if ext_attrs:
++                    ext_attrs = f"{ext_attrs} "
++                ext_attrs = f"{ext_attrs}trusted=yes"
++            parts = [
++                "#" if disabled else "",
++                type,
++                f"[{ext_attrs}]" if ext_attrs else "",
++                uri,
++                dist,
++            ]
++            parts.extend(comps)
++            if comment:
++                parts.append("#" + comment)
++            line = " ".join(part for part in parts if part) + "\n"
++
++            new_entry = SourceEntry(line)
++            if file is not None:
++                new_entry.file = file
++
++        if pos < 0:
++            self.list.append(new_entry)
++        else:
++            self.list.insert(pos, new_entry)
++        return new_entry
++
++    def remove(self, source_entry):
++        """
++        Remove the entry from the sources.list
++        """
++        self.list.remove(source_entry)
++
++    def load_deb822_sections(self, file_obj):
++        """
++        Return Deb822 sections from .sources file object
++        """
++        sections = []
++        section = ""
++        for line in file_obj:
++            if not line.isspace():
++                # Consider not empty line as a part of a section
++                section += line
++            elif section:
++                # Add a new section on getting first space line
++                sections.append(Deb822Section(section))
++                section = ""
++
++        # Create the last section if we still have data for it
++        if section:
++            sections.append(Deb822Section(section))
++
++        return sections
++
++    def load(self, file_path):
++        """
++        Load the sources from the file
++        """
++        try:
++            with salt.utils.files.fopen(file_path) as f:
++                if file_path.endswith(".sources"):
++                    for section in self.load_deb822_sections(f):
++                        self.list.append(
++                            Deb822SourceEntry(section, file_path, list=self)
++                        )
++                else:
++                    for line in f:
++                        source = SourceEntry(line, file_path)
++                        self.list.append(source)
++        except Exception as exc:  # pylint: disable=broad-except
++            log.error("Could not parse source file '%s'", file_path, exc_info=True)
++
++    def index(self, entry):
++        return self.list.index(entry)
++
++    def save(self):
++        """save the current sources"""
++        # write an empty default config file if there aren't any sources
++        if len(self.list) == 0:
++            path = _APT_SOURCES_LIST
++            header = (
++                "## See sources.list(5) for more information, especialy\n"
++                "# Remember that you can only use http, ftp or file URIs\n"
++                "# CDROMs are managed through the apt-cdrom tool.\n"
++            )
++
++            try:
++                with salt.utils.files.fopen(path, "w") as f:
++                    f.write(header)
++            except FileNotFoundError:
++                # No need to create file if there is no apt directory
++                pass
++            return
++
++        files = {}
++        for source in self.list:
++            if source.file not in files:
++                files[source.file] = []
++            elif isinstance(source, Deb822SourceEntry):
++                files[source.file].append("\n")
++            files[source.file].append(str(source) + "\n")
++        for file in files:
++            with salt.utils.files.fopen(file, "w") as f:
++                f.write("".join(files[file]))
++
++
++def _invalid(line):
++    """
++    This is a workaround since python3-apt does not support
++    the signed-by argument. This function was removed from
++    the class to ensure users using the python3-apt module or
++    not can use the signed-by option.
++    """
++    disabled = False
++    invalid = False
++    comment = ""
++    line = line.strip()
++    if not line:
++        invalid = True
++        return disabled, invalid, comment, ""
++
++    if line.startswith("#"):
++        disabled = True
++        line = line[1:]
++
++    idx = line.find("#")
++    if idx > 0:
++        comment = line[idx + 1 :]
++        line = line[:idx]
++
++    cdrom_match = re.match(r"(.*)(cdrom:.*/)(.*)", line.strip())
++    if cdrom_match:
++        repo_line = (
++            [p.strip() for p in cdrom_match.group(1).split()]
++            + [cdrom_match.group(2).strip()]
++            + [p.strip() for p in cdrom_match.group(3).split()]
++        )
++    else:
++        repo_line = line.strip().split()
++    if (
++        not repo_line
++        or repo_line[0] not in ["deb", "deb-src", "rpm", "rpm-src"]
++        or len(repo_line) < 3
++    ):
++        invalid = True
++        return disabled, invalid, comment, repo_line
++
++    if repo_line[1].startswith("["):
++        if not any(x.endswith("]") for x in repo_line[1:]):
++            invalid = True
++            return disabled, invalid, comment, repo_line
++
++    return disabled, invalid, comment, repo_line
++
++
++def _get_opts(line):
++    """
++    Return all opts in [] for a repo line
++    """
++    get_opts = re.search(r"\[(.*?=.*?)\]", line)
++    ret = OrderedDict()
++
++    if not get_opts:
++        return ret
++    opts = get_opts.group(0).strip("[]")
++    architectures = []
++    for opt in opts.split():
++        if opt.startswith("arch"):
++            architectures.extend(opt.split("=", 1)[1].split(","))
++            ret["arch"] = {}
++            ret["arch"]["full"] = opt
++            ret["arch"]["value"] = architectures
++        elif opt.startswith("signed-by"):
++            ret["signedby"] = {}
++            ret["signedby"]["full"] = opt
++            ret["signedby"]["value"] = opt.split("=", 1)[1]
++        else:
++            other_opt = opt.split("=", 1)[0]
++            ret[other_opt] = {}
++            ret[other_opt]["full"] = opt
++            ret[other_opt]["value"] = opt.split("=", 1)[1]
++    return ret
++
+ 
+ def combine_comments(comments):
+     """
+diff --git a/tests/pytests/functional/modules/test_pkg.py b/tests/pytests/functional/modules/test_pkg.py
+index c80bb3b0c3..bd9a2093cb 100644
+--- a/tests/pytests/functional/modules/test_pkg.py
++++ b/tests/pytests/functional/modules/test_pkg.py
+@@ -219,12 +219,15 @@ def test_owner(modules, grains):
+ # Similar to pkg.owner, but for FreeBSD's pkgng
+ @pytest.mark.skip_on_freebsd(reason="test for new package manager for FreeBSD")
+ @pytest.mark.requires_salt_modules("pkg.which")
+-def test_which(modules):
++def test_which(grains, modules):
+     """
+     test finding the package owning a file
+     """
+-    func = "pkg.which"
+-    ret = modules.pkg.which("/usr/local/bin/salt-call")
++    if grains["os_family"] in ["Debian", "RedHat"]:
++        file = "/bin/mknod"
++    else:
++        file = "/usr/local/bin/salt-call"
++    ret = modules.pkg.which(file)
+     assert len(ret) != 0
+ 
+ 
+diff --git a/tests/pytests/functional/states/pkgrepo/test_debian.py b/tests/pytests/functional/states/pkgrepo/test_debian.py
+index 45afaf2574..8d91f2168c 100644
+--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
++++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
+@@ -1,10 +1,6 @@
+-import glob
+ import logging
+ import os
+ import pathlib
+-import shutil
+-import sys
+-import sysconfig
+ 
+ import _pytest._version
+ import attr
+@@ -12,7 +8,6 @@ import pytest
+ import requests
+ 
+ import salt.utils.files
+-from tests.conftest import CODE_DIR
+ 
+ PYTEST_GE_7 = getattr(_pytest._version, "version_tuple", (-1, -1)) >= (7, 0)
+ 
+@@ -39,12 +34,12 @@ def pkgrepo(states, grains):
+ 
+ 
+ @pytest.mark.requires_salt_states("pkgrepo.managed")
+-def test_adding_repo_file(pkgrepo, tmp_path):
++def test_adding_repo_file(pkgrepo, repo_uri, tmp_path):
+     """
+     test adding a repo file using pkgrepo.managed
+     """
+     repo_file = str(tmp_path / "stable-binary.list")
+-    repo_content = "deb http://www.deb-multimedia.org stable main"
++    repo_content = f"deb {repo_uri} stable main"
+     ret = pkgrepo.managed(name=repo_content, file=repo_file, clean_file=True)
+     with salt.utils.files.fopen(repo_file, "r") as fp:
+         file_content = fp.read()
+@@ -52,30 +47,24 @@ def test_adding_repo_file(pkgrepo, tmp_path):
+ 
+ 
+ @pytest.mark.requires_salt_states("pkgrepo.managed")
+-def test_adding_repo_file_arch(pkgrepo, tmp_path, subtests):
++def test_adding_repo_file_arch(pkgrepo, repo_uri, tmp_path, subtests):
+     """
+     test adding a repo file using pkgrepo.managed
+     and setting architecture
+     """
+     repo_file = str(tmp_path / "stable-binary.list")
+-    repo_content = "deb [arch=amd64  ] http://www.deb-multimedia.org stable main"
++    repo_content = f"deb [arch=amd64  ] {repo_uri} stable main"
+     pkgrepo.managed(name=repo_content, file=repo_file, clean_file=True)
+     with salt.utils.files.fopen(repo_file, "r") as fp:
+         file_content = fp.read()
+-        assert (
+-            file_content.strip()
+-            == "deb [arch=amd64] http://www.deb-multimedia.org stable main"
+-        )
++        assert file_content.strip() == f"deb [arch=amd64] {repo_uri} stable main"
+     with subtests.test("With multiple archs"):
+-        repo_content = (
+-            "deb [arch=amd64,i386  ] http://www.deb-multimedia.org stable main"
+-        )
++        repo_content = f"deb [arch=amd64,i386  ] {repo_uri} stable main"
+         pkgrepo.managed(name=repo_content, file=repo_file, clean_file=True)
+         with salt.utils.files.fopen(repo_file, "r") as fp:
+             file_content = fp.read()
+             assert (
+-                file_content.strip()
+-                == "deb [arch=amd64,i386] http://www.deb-multimedia.org stable main"
++                file_content.strip() == f"deb [arch=amd64,i386] {repo_uri} stable main"
+             )
+ 
+ 
+@@ -97,98 +86,8 @@ def test_adding_repo_file_cdrom(pkgrepo, tmp_path):
+         )
+ 
+ 
+-def system_aptsources_ids(value):
+-    return "{}(aptsources.sourceslist)".format(value.title())
+-
+-
+-@pytest.fixture(
+-    params=("with", "without"), ids=system_aptsources_ids, scope="module", autouse=True
+-)
+-def system_aptsources(request, grains):
+-    sys_modules = list(sys.modules)
+-    copied_paths = []
+-    exc_kwargs = {}
+-    if PYTEST_GE_7:
+-        exc_kwargs["_use_item_location"] = True
+-    if grains["os_family"] != "Debian":
+-        raise pytest.skip.Exception(
+-            "Test only for debian based platforms", **exc_kwargs
+-        )
+-    try:
+-        try:
+-            from aptsources import sourceslist  # pylint: disable=unused-import
+-
+-            if request.param == "without":
+-                raise pytest.skip.Exception(
+-                    "This test is meant to run without the system aptsources package, but it's "
+-                    "available from '{}'.".format(sourceslist.__file__),
+-                    **exc_kwargs
+-                )
+-            else:
+-                # Run the test
+-                yield request.param
+-        except ImportError:
+-            if request.param == "without":
+-                # Run the test
+-                yield
+-            else:
+-                copied_paths = []
+-                py_version_keys = [
+-                    "{}".format(*sys.version_info),
+-                    "{}.{}".format(*sys.version_info),
+-                ]
+-                session_site_packages_dir = sysconfig.get_path(
+-                    "purelib"
+-                )  # note: platlib and purelib could differ
+-                session_site_packages_dir = os.path.relpath(
+-                    session_site_packages_dir, str(CODE_DIR)
+-                )
+-                for py_version in py_version_keys:
+-                    dist_packages_path = "/usr/lib/python{}/dist-packages".format(
+-                        py_version
+-                    )
+-                    if not os.path.isdir(dist_packages_path):
+-                        continue
+-                    for aptpkg in glob.glob(os.path.join(dist_packages_path, "*apt*")):
+-                        src = os.path.realpath(aptpkg)
+-                        dst = os.path.join(
+-                            session_site_packages_dir, os.path.basename(src)
+-                        )
+-                        if os.path.exists(dst):
+-                            log.info(
+-                                "Not overwritting already existing %s with %s", dst, src
+-                            )
+-                            continue
+-                        log.info("Copying %s into %s", src, dst)
+-                        copied_paths.append(dst)
+-                        if os.path.isdir(src):
+-                            shutil.copytree(src, dst)
+-                        else:
+-                            shutil.copyfile(src, dst)
+-                if not copied_paths:
+-                    raise pytest.skip.Exception(
+-                        "aptsources.sourceslist python module not found", **exc_kwargs
+-                    )
+-                # Run the test
+-                yield request.param
+-    finally:
+-        for path in copied_paths:
+-            log.info("Deleting %r", path)
+-            if os.path.isdir(path):
+-                shutil.rmtree(path, ignore_errors=True)
+-            else:
+-                os.unlink(path)
+-        for name in list(sys.modules):
+-            if name in sys_modules:
+-                continue
+-            if "apt" not in name:
+-                continue
+-            log.debug("Removing '%s' from 'sys.modules'", name)
+-            sys.modules.pop(name)
+-
+-
+ @pytest.fixture
+-def ubuntu_state_tree(system_aptsources, state_tree, grains):
++def ubuntu_state_tree(state_tree, grains):
+     if grains["os"] != "Ubuntu":
+         pytest.skip(
+             "Test only applicable to Ubuntu, not '{}'".format(grains["osfinger"])
+@@ -378,7 +277,7 @@ def test_pkgrepo_with_architectures(pkgrepo, grains, sources_list_file, subtests
+     )
+ 
+     def _get_arch(arch):
+-        return "[arch={}] ".format(arch) if arch else ""
++        return f"[arch={arch}] " if arch else ""
+ 
+     def _run(arch=None, test=False):
+         return pkgrepo.managed(
+@@ -498,6 +397,11 @@ def test_pkgrepo_with_architectures(pkgrepo, grains, sources_list_file, subtests
+         assert ret.result is True
+ 
+ 
++@pytest.fixture(scope="module")
++def repo_uri(grains):
++    yield "http://www.deb-multimedia.org"
++
++
+ @pytest.fixture
+ def trailing_slash_repo_file(grains):
+     if grains["os_family"] != "Debian":
+@@ -517,19 +421,21 @@ def trailing_slash_repo_file(grains):
+ 
+ 
+ @pytest.mark.requires_salt_states("pkgrepo.managed", "pkgrepo.absent")
+-def test_repo_present_absent_trailing_slash_uri(pkgrepo, trailing_slash_repo_file):
++def test_repo_present_absent_trailing_slash_uri(
++    pkgrepo, repo_uri, trailing_slash_repo_file
++):
+     """
+     test adding a repo with a trailing slash in the uri
+     """
+     # with the trailing slash
+-    repo_content = "deb http://www.deb-multimedia.org/ stable main"
++    repo_content = f"deb {repo_uri}/ stable main"
+     # initial creation
+     ret = pkgrepo.managed(
+         name=repo_content, file=trailing_slash_repo_file, refresh=False, clean_file=True
+     )
+     with salt.utils.files.fopen(trailing_slash_repo_file, "r") as fp:
+         file_content = fp.read()
+-    assert file_content.strip() == "deb http://www.deb-multimedia.org/ stable main"
++    assert file_content.strip() == f"deb {repo_uri}/ stable main"
+     assert ret.changes
+     # no changes
+     ret = pkgrepo.managed(
+@@ -542,19 +448,21 @@ def test_repo_present_absent_trailing_slash_uri(pkgrepo, trailing_slash_repo_fil
+ 
+ 
+ @pytest.mark.requires_salt_states("pkgrepo.managed", "pkgrepo.absent")
+-def test_repo_present_absent_no_trailing_slash_uri(pkgrepo, trailing_slash_repo_file):
++def test_repo_present_absent_no_trailing_slash_uri(
++    pkgrepo, repo_uri, trailing_slash_repo_file
++):
+     """
+     test adding a repo with a trailing slash in the uri
+     """
+     # without the trailing slash
+-    repo_content = "deb http://www.deb-multimedia.org stable main"
++    repo_content = f"deb {repo_uri} stable main"
+     # initial creation
+     ret = pkgrepo.managed(
+         name=repo_content, file=trailing_slash_repo_file, refresh=False, clean_file=True
+     )
+     with salt.utils.files.fopen(trailing_slash_repo_file, "r") as fp:
+         file_content = fp.read()
+-    assert file_content.strip() == "deb http://www.deb-multimedia.org stable main"
++    assert file_content.strip() == repo_content
+     assert ret.changes
+     # no changes
+     ret = pkgrepo.managed(
+@@ -568,35 +476,74 @@ def test_repo_present_absent_no_trailing_slash_uri(pkgrepo, trailing_slash_repo_
+ 
+ @pytest.mark.requires_salt_states("pkgrepo.managed", "pkgrepo.absent")
+ def test_repo_present_absent_no_trailing_slash_uri_add_slash(
+-    pkgrepo, trailing_slash_repo_file
++    pkgrepo, repo_uri, trailing_slash_repo_file
+ ):
+     """
+     test adding a repo without a trailing slash, and then running it
+     again with a trailing slash.
+     """
+     # without the trailing slash
+-    repo_content = "deb http://www.deb-multimedia.org stable main"
++    repo_content = f"deb {repo_uri} stable main"
+     # initial creation
+     ret = pkgrepo.managed(
+         name=repo_content, file=trailing_slash_repo_file, refresh=False, clean_file=True
+     )
+     with salt.utils.files.fopen(trailing_slash_repo_file, "r") as fp:
+         file_content = fp.read()
+-    assert file_content.strip() == "deb http://www.deb-multimedia.org stable main"
++    assert file_content.strip() == repo_content
+     assert ret.changes
+     # now add a trailing slash in the name
+-    repo_content = "deb http://www.deb-multimedia.org/ stable main"
++    repo_content = f"deb {repo_uri}/ stable main"
+     ret = pkgrepo.managed(
+         name=repo_content, file=trailing_slash_repo_file, refresh=False
+     )
+     with salt.utils.files.fopen(trailing_slash_repo_file, "r") as fp:
+         file_content = fp.read()
+-    assert file_content.strip() == "deb http://www.deb-multimedia.org/ stable main"
++    assert file_content.strip() == repo_content
+     # absent
+     ret = pkgrepo.absent(name=repo_content)
+     assert ret.result
+ 
+ 
++@pytest.mark.requires_salt_states("pkgrepo.managed", "pkgrepo.absent")
++def test_repo_absent_trailing_slash_in_uri(
++    pkgrepo, repo_uri, subtests, trailing_slash_repo_file
++):
++    """
++    Test pkgrepo.absent with a URI containing a trailing slash
++
++    See https://github.com/saltstack/salt/issues/64286
++    """
++    repo_file = pathlib.Path(trailing_slash_repo_file)
++    repo_content = f"deb [arch=amd64] {repo_uri}/ stable main"
++
++    with subtests.test("Remove repo with trailing slash in URI"):
++        # Write contents to file with trailing slash in URI
++        repo_file.write_text(f"{repo_content}\n")
++        # Perform and validate removal
++        ret = pkgrepo.absent(name=repo_content)
++        assert ret.result
++        assert ret.changes
++        assert not repo_file.exists()
++        # A second run of the pkgrepo.absent state should be a no-op (i.e. no changes)
++        ret = pkgrepo.absent(name=repo_content)
++        assert ret.result
++        assert not ret.changes
++        assert not repo_file.exists()
++
++    with subtests.test("URI match with mismatched arch"):
++        # Create a repo file that matches the URI but contains no architecture.
++        # This should not be identified as a match for repo_content, and thus
++        # the result of a state should be a no-op.
++        repo_file.write_text(f"deb {repo_uri} stable main\n")
++        # Since this was a no-op, the state should have succeeded, made no
++        # changes, and left the repo file in place.
++        ret = pkgrepo.absent(name=repo_content)
++        assert ret.result
++        assert not ret.changes
++        assert repo_file.exists()
++
++
+ @attr.s(kw_only=True)
+ class Repo:
+     key_root = attr.ib(default=pathlib.Path("/usr", "share", "keyrings"))
+@@ -804,3 +751,214 @@ def test_adding_repo_file_signedby_alt_file(pkgrepo, states, repo):
+         assert file_content.endswith("\n")
+     assert key_file.is_file()
+     assert repo_content in ret.comment
++
++
++@pytest.fixture
++def deb822_repo_file(grains):
++    if grains["os_family"] != "Debian":
++        pytest.skip(
++            "Test only applicable to Debian flavors, not '{}'".format(
++                grains["osfinger"]
++            )
++        )
++    repo_file_path = "/etc/apt/sources.list.d/deb822-test.sources"
++    try:
++        yield repo_file_path
++    finally:
++        try:
++            os.unlink(repo_file_path)
++        except OSError:
++            pass
++
++
++@pytest.mark.requires_salt_states("pkgrepo.managed", "pkgrepo.absent")
++def test_repo_present_absent_deb822_repo_file(
++    pkgrepo, grains, deb822_repo_file, subtests
++):
++    """
++    test adding and managing a deb822 repo.
++    """
++    codename = grains["oscodename"]
++    repo_uri_main = "http://ftp.es.debian.org/debian"
++    repo_uri_alt = "http://ftp.cz.debian.org/debian"
++    aptkey = True if salt.utils.path.which("apt-key") else False
++    ext_attrs = ""
++    expected_ext_attrs = ""
++    if not aptkey:
++        ext_attrs = " [signed-by=/usr/share/keyrings/elasticsearch-keyring.gpg]"
++        expected_ext_attrs = (
++            "\nSigned-By: /usr/share/keyrings/elasticsearch-keyring.gpg"
++        )
++
++    # without the trailing slash
++    repo_content = f"deb{ext_attrs} {repo_uri_main} {codename} main"
++    expected_content = f"""Types: deb
++URIs: {repo_uri_main}
++Suites: {codename}
++Components: main{expected_ext_attrs}"""
++    with subtests.test("Create new deb822 repo source"):
++        # initial creation
++        ret = pkgrepo.managed(
++            name=repo_content, file=deb822_repo_file, refresh=False, clean_file=True
++        )
++        with salt.utils.files.fopen(deb822_repo_file, "r") as fp:
++            file_content = fp.read()
++        assert file_content.strip() == expected_content
++        assert ret.changes
++
++    # use trailing slash in the URI and add extra suites
++    repo_content = f"deb{ext_attrs} {repo_uri_main}/ {codename} main"
++    expected_content = f"""Types: deb
++URIs: {repo_uri_main}/
++Suites: {codename} {codename}-updates {codename}-backports
++Components: main{expected_ext_attrs}"""
++    with subtests.test("Add suites to deb822 repo source"):
++        ret = pkgrepo.managed(
++            name=repo_content,
++            file=deb822_repo_file,
++            refresh=False,
++            suites=[codename, f"{codename}-updates", f"{codename}-backports"],
++        )
++        with salt.utils.files.fopen(deb822_repo_file, "r") as fp:
++            file_content = fp.read()
++        assert file_content.strip() == expected_content
++        assert ret.changes
++
++    # use trailing slash in the URI and add extra components
++    repo_content = f"deb{ext_attrs} {repo_uri_main}/ {codename} main"
++    expected_content = f"""Types: deb
++URIs: {repo_uri_main}/
++Suites: {codename} {codename}-updates {codename}-backports
++Components: main contrib{expected_ext_attrs}"""
++    with subtests.test("Add comps to deb822 repo source"):
++        ret = pkgrepo.managed(
++            name=repo_content,
++            file=deb822_repo_file,
++            refresh=False,
++            comps="main,contrib",
++        )
++        with salt.utils.files.fopen(deb822_repo_file, "r") as fp:
++            file_content = fp.read()
++        assert file_content.strip() == expected_content
++        assert ret.changes
++
++    # use trailing slash in the URI and add extra type
++    repo_content = f"deb{ext_attrs} {repo_uri_main}/ {codename} main contrib"
++    expected_content = f"""Types: deb deb-src
++URIs: {repo_uri_main}/
++Suites: {codename} {codename}-updates {codename}-backports
++Components: main contrib{expected_ext_attrs}"""
++    with subtests.test("Add type to deb822 repo source"):
++        ret = pkgrepo.managed(
++            name=repo_content,
++            file=deb822_repo_file,
++            refresh=False,
++            types=["deb", "deb-src"],
++        )
++        with salt.utils.files.fopen(deb822_repo_file, "r") as fp:
++            file_content = fp.read()
++        assert file_content.strip() == expected_content
++        assert ret.changes
++
++    # do not use trailing slash in the URI and add extra URI
++    repo_content = f"deb{ext_attrs} {repo_uri_main} {codename} main contrib"
++    expected_content = f"""Types: deb deb-src
++URIs: {repo_uri_main} {repo_uri_alt}
++Suites: {codename} {codename}-updates {codename}-backports
++Components: main contrib{expected_ext_attrs}"""
++    with subtests.test("Add extra URI to deb822 repo source"):
++        ret = pkgrepo.managed(
++            name=repo_content,
++            file=deb822_repo_file,
++            refresh=False,
++            uris=[repo_uri_main, repo_uri_alt],
++        )
++        with salt.utils.files.fopen(deb822_repo_file, "r") as fp:
++            file_content = fp.read()
++        assert file_content.strip() == expected_content
++        assert ret.changes
++
++    # do not use trailing slash in the URI and remove suites
++    repo_content = f"deb{ext_attrs} {repo_uri_main} {codename} main contrib"
++    expected_content = f"""Types: deb deb-src
++URIs: {repo_uri_main} {repo_uri_alt}
++Suites: {codename}
++Components: main contrib{expected_ext_attrs}"""
++    with subtests.test("Remove suites from deb822 repo source"):
++        ret = pkgrepo.managed(
++            name=repo_content,
++            file=deb822_repo_file,
++            refresh=False,
++            suites=[codename],
++        )
++        with salt.utils.files.fopen(deb822_repo_file, "r") as fp:
++            file_content = fp.read()
++        assert file_content.strip() == expected_content
++        assert ret.changes
++
++    # Add one more repo source to the existing source file
++    repo_uri_main_sec = "http://ftp.cz.debian.org/debian-security"
++    repo_uri_alt_sec = "http://ftp.es.debian.org/debian-security"
++    repo_content_sec = (
++        f"deb{ext_attrs} {repo_uri_main_sec} {codename}-security main updates"
++    )
++    expected_content = f"""Types: deb deb-src
++URIs: {repo_uri_main} {repo_uri_alt}
++Suites: {codename}
++Components: main contrib{expected_ext_attrs}
++
++Types: deb
++URIs: {repo_uri_main_sec} {repo_uri_alt_sec}
++Suites: {codename}-security
++Components: main updates{expected_ext_attrs}"""
++    with subtests.test("Add extra deb822 repo source"):
++        ret = pkgrepo.managed(
++            name=repo_content_sec,
++            file=deb822_repo_file,
++            refresh=False,
++            uris=[repo_uri_main_sec, repo_uri_alt_sec],
++        )
++        with salt.utils.files.fopen(deb822_repo_file, "r") as fp:
++            file_content = fp.read()
++        assert file_content.strip() == expected_content
++        assert ret.changes
++
++    # Disable repo source and leave just alternative URI
++    repo_content_sec = (
++        f"deb{ext_attrs} {repo_uri_main_sec} {codename}-security main updates"
++    )
++    expected_content = f"""Types: deb deb-src
++URIs: {repo_uri_main} {repo_uri_alt}
++Suites: {codename}
++Components: main contrib{expected_ext_attrs}
++
++Types: deb
++URIs: {repo_uri_alt_sec}
++Suites: {codename}-security
++Components: main updates{expected_ext_attrs}
++Enabled: no"""
++    with subtests.test("Disable extra deb822 repo source"):
++        ret = pkgrepo.managed(
++            name=repo_content_sec,
++            file=deb822_repo_file,
++            refresh=False,
++            uris=[repo_uri_alt_sec],
++            disabled=True,
++        )
++        with salt.utils.files.fopen(deb822_repo_file, "r") as fp:
++            file_content = fp.read()
++        assert file_content.strip() == expected_content
++        assert ret.changes
++
++    # Remove repo source
++    expected_content = f"""Types: deb
++URIs: {repo_uri_alt_sec}
++Suites: {codename}-security
++Components: main updates{expected_ext_attrs}
++Enabled: no"""
++    with subtests.test("Remove deb822 repo source"):
++        ret = pkgrepo.absent(name=repo_content)
++        with salt.utils.files.fopen(deb822_repo_file, "r") as fp:
++            file_content = fp.read()
++        assert ret.result
++        assert file_content.strip() == expected_content
+diff --git a/tests/pytests/functional/utils/pkg/__init__.py b/tests/pytests/functional/utils/pkg/__init__.py
+new file mode 100644
+index 0000000000..e69de29bb2
+diff --git a/tests/pytests/functional/utils/pkg/test_deb.py b/tests/pytests/functional/utils/pkg/test_deb.py
+new file mode 100644
+index 0000000000..37b1fb0ed3
+--- /dev/null
++++ b/tests/pytests/functional/utils/pkg/test_deb.py
+@@ -0,0 +1,88 @@
++import salt.utils.pkg.deb
++from salt.utils.pkg.deb import SourceEntry
++
++
++def test__get_opts():
++    tests = [
++        {
++            "oneline": "deb [signed-by=/etc/apt/keyrings/example.key arch=amd64] https://example.com/pub/repos/apt xenial main",
++            "result": {
++                "signedby": {
++                    "full": "signed-by=/etc/apt/keyrings/example.key",
++                    "value": "/etc/apt/keyrings/example.key",
++                },
++                "arch": {"full": "arch=amd64", "value": ["amd64"]},
++            },
++        },
++        {
++            "oneline": "deb [arch=amd64 signed-by=/etc/apt/keyrings/example.key]  https://example.com/pub/repos/apt xenial main",
++            "result": {
++                "arch": {"full": "arch=amd64", "value": ["amd64"]},
++                "signedby": {
++                    "full": "signed-by=/etc/apt/keyrings/example.key",
++                    "value": "/etc/apt/keyrings/example.key",
++                },
++            },
++        },
++        {
++            "oneline": "deb [arch=amd64]  https://example.com/pub/repos/apt xenial main",
++            "result": {
++                "arch": {"full": "arch=amd64", "value": ["amd64"]},
++            },
++        },
++    ]
++
++    for test in tests:
++        ret = salt.utils.pkg.deb._get_opts(test["oneline"])
++        assert ret == test["result"]
++
++
++def test_SourceEntry_init():
++    source = SourceEntry(
++        "deb [arch=amd64 signed-by=/etc/apt/keyrings/example.key] https://example.com/pub/repos/apt xenial main",
++        file="/tmp/test.list",
++    )
++    assert source.invalid is False
++    assert source.comps == ["main"]
++    assert source.comment == ""
++    assert source.dist == "xenial"
++    assert source.type == "deb"
++    assert source.uri == "https://example.com/pub/repos/apt"
++    assert source.architectures == ["amd64"]
++    assert source.signedby == "/etc/apt/keyrings/example.key"
++    assert source.file == "/tmp/test.list"
++
++
++def test_SourceEntry_repo_line():
++
++    lines = [
++        "deb [arch=amd64 signed-by=/etc/apt/keyrings/example.key] https://example.com/pub/repos/apt xenial main\n",
++        "deb [signed-by=/etc/apt/keyrings/example.key] https://example.com/pub/repos/apt xenial main\n",
++        "deb [signed-by=/etc/apt/keyrings/example.key arch=amd64,x86_64] https://example.com/pub/repos/apt xenial main\n",
++    ]
++    for line in lines:
++        source = SourceEntry(line, file="/tmp/test.list")
++        assert source.invalid is False
++        assert source.repo_line() == line
++
++    lines = [
++        (
++            "deb [arch=amd64 signed-by=/etc/apt/keyrings/example.key] https://example.com/pub/repos/apt xenial main\n",
++            "deb [arch=x86_64 signed-by=/etc/apt/keyrings/example.key] https://example.com/pub/repos/apt xenial main\n",
++        ),
++        (
++            "deb [signed-by=/etc/apt/keyrings/example.key] https://example.com/pub/repos/apt xenial main\n",
++            "deb [signed-by=/etc/apt/keyrings/example.key arch=x86_64] https://example.com/pub/repos/apt xenial main\n",
++        ),
++        (
++            "deb [signed-by=/etc/apt/keyrings/example.key arch=amd64,x86_64] https://example.com/pub/repos/apt xenial main\n",
++            "deb [signed-by=/etc/apt/keyrings/example.key arch=x86_64] https://example.com/pub/repos/apt xenial main\n",
++        ),
++    ]
++    for line in lines:
++        line_key, line_value = line
++        source = SourceEntry(line_key, file="/tmp/test.list")
++        source.architectures = ["x86_64"]
++        assert source.invalid is False
++        assert source.repo_line() == line_value
++        assert source.invalid is False
+diff --git a/tests/pytests/unit/modules/test_aptpkg.py b/tests/pytests/unit/modules/test_aptpkg.py
+index 3d7c004ef7..2e2b73b856 100644
+--- a/tests/pytests/unit/modules/test_aptpkg.py
++++ b/tests/pytests/unit/modules/test_aptpkg.py
+@@ -5,7 +5,6 @@
+     versionadded:: 2017.7.0
+ """
+ 
+-
+ import copy
+ import importlib
+ import logging
+@@ -25,42 +24,6 @@ from salt.exceptions import (
+ )
+ from tests.support.mock import MagicMock, Mock, call, mock_open, patch
+ 
+-try:
+-    from aptsources.sourceslist import (  # pylint: disable=unused-import
+-        SourceEntry,
+-        SourcesList,
+-    )
+-
+-    HAS_APT = True
+-except ImportError:
+-    HAS_APT = False
+-
+-try:
+-    from aptsources import sourceslist  # pylint: disable=unused-import
+-
+-    HAS_APTSOURCES = True
+-except ImportError:
+-    HAS_APTSOURCES = False
+-
+-HAS_DEB822 = False
+-
+-if HAS_APT:
+-    try:
+-        from aptsources.sourceslist import Deb822SourceEntry, _deb822 # pylint: disable=unused-import
+-
+-        HAS_DEB822 = True
+-    except ImportError:
+-        pass
+-
+-HAS_APT_PKG = False
+-
+-try:
+-    import apt_pkg
+-
+-    HAS_APT_PKG = True
+-except ImportError:
+-    pass
+-
+ log = logging.getLogger(__name__)
+ 
+ 
+@@ -226,17 +189,18 @@ def _get_uri(repo):
+ class MockSourceEntry:
+     def __init__(self, uri, source_type, line, invalid, dist="", file=None):
+         self.uri = uri
++        self.uris = [uri]
+         self.type = source_type
++        self.types = [source_type]
+         self.line = line
+         self.invalid = invalid
+         self.file = file
+         self.disabled = False
+         self.dist = dist
++        self.suites = [dist]
+         self.comps = []
+         self.architectures = []
+         self.signedby = ""
+-        if HAS_DEB822:
+-            self.types = []
+ 
+     def mysplit(self, line):
+         return line.split()
+@@ -285,26 +249,25 @@ def deb822_repo_file(tmp_path: pathlib.Path, deb822_repo_content: str):
+ def mock_apt_config(deb822_repo_file: pathlib.Path):
+     """
+     Mocking common to deb822 testing so that apt_pkg uses the
+-    tmp_path/sources.list.d as the Dir::Etc::sourceparts location
++    tmp_path/sources.list.d as the sourceparts location
+     """
+     with patch.dict(
+         aptpkg.__salt__,
+         {"config.option": MagicMock()},
+-    ), patch.object(apt_pkg, "config") as mock_config:
+-        mock_config.find_file.return_value = "/etc/apt/sources.list"
+-        mock_config.find_dir.return_value = os.path.dirname(str(deb822_repo_file))
++    ) as mock_config, patch(
++        "salt.utils.pkg.deb._APT_SOURCES_PARTSDIR",
++        os.path.dirname(str(deb822_repo_file)),
++    ):
+         yield mock_config
+ 
+ 
+-@pytest.mark.skipif(not HAS_DEB822, reason="Requires deb822 support")
+-@pytest.mark.skipif(not HAS_APT_PKG, reason="Requires debian/ubuntu apt_pkg system library")
+ def test_mod_repo_deb822_modify(deb822_repo_file: pathlib.Path, mock_apt_config):
+     """
+     Test that aptpkg can modify an existing repository in the deb822 format.
+     In this test, we match the repository by name and disable it.
+     """
+     uri = "http://cz.archive.ubuntu.com/ubuntu/"
+-    repo = f"deb {uri} noble main"
++    repo = f"deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] {uri} noble main"
+ 
+     aptpkg.mod_repo(repo, enabled=False, file=str(deb822_repo_file), refresh_db=False)
+ 
+@@ -313,14 +276,12 @@ def test_mod_repo_deb822_modify(deb822_repo_file: pathlib.Path, mock_apt_config)
+     assert f"URIs: {uri}" in repo_file
+ 
+ 
+-@pytest.mark.skipif(not HAS_DEB822, reason="Requires deb822 support")
+-@pytest.mark.skipif(not HAS_APT_PKG, reason="Requires debian/ubuntu apt_pkg system library")
+ def test_mod_repo_deb822_add(deb822_repo_file: pathlib.Path, mock_apt_config):
+     """
+     Test that aptpkg can add a repository in the deb822 format.
+     """
+     uri = "http://security.ubuntu.com/ubuntu/"
+-    repo = f"deb {uri} noble-security main"
++    repo = f"deb [signed-by=/usr/share/keyrings/ubuntu-archive-keyring.gpg] {uri} noble-security main"
+ 
+     aptpkg.mod_repo(repo, file=str(deb822_repo_file), refresh_db=False)
+ 
+@@ -329,23 +290,26 @@ def test_mod_repo_deb822_add(deb822_repo_file: pathlib.Path, mock_apt_config):
+     assert "URIs: http://cz.archive.ubuntu.com/ubuntu/" in repo_file
+ 
+ 
+-@pytest.mark.skipif(not HAS_DEB822, reason="Requires deb822 support")
+-@pytest.mark.skipif(not HAS_APT_PKG, reason="Requires debian/ubuntu apt_pkg system library")
+ def test_del_repo_deb822(deb822_repo_file: pathlib.Path, mock_apt_config):
+     """
+     Test that aptpkg can delete a repository in the deb822 format.
+     """
+     uri = "http://cz.archive.ubuntu.com/ubuntu/"
+-    repo = f"deb {uri} noble main"
+ 
+     with patch.object(aptpkg, "refresh_db"):
++        repo = f"deb {uri} noble main"
+         aptpkg.del_repo(repo, file=str(deb822_repo_file))
++        assert os.path.isfile(str(deb822_repo_file))
+ 
+-    assert not os.path.isfile(str(deb822_repo_file))
++        repo = f"deb {uri} noble-updates main"
++        aptpkg.del_repo(repo, file=str(deb822_repo_file))
++        assert os.path.isfile(str(deb822_repo_file))
++
++        repo = f"deb {uri} noble-backports main"
++        aptpkg.del_repo(repo, file=str(deb822_repo_file))
++        assert not os.path.isfile(str(deb822_repo_file))
+ 
+ 
+-@pytest.mark.skipif(not HAS_DEB822, reason="Requires deb822 support")
+-@pytest.mark.skipif(not HAS_APT_PKG, reason="Requires debian/ubuntu apt_pkg system library")
+ def test_get_repo_deb822(deb822_repo_file: pathlib.Path, mock_apt_config):
+     """
+     Test that aptpkg can match a repository in the deb822 format.
+@@ -424,12 +388,9 @@ def test_get_repo_keys(repo_keys_var):
+     mock = MagicMock(return_value={"retcode": 0, "stdout": APT_KEY_LIST})
+ 
+     with patch.dict(aptpkg.__salt__, {"cmd.run_all": mock}):
+-        if not HAS_APT:
+-            with patch("os.listdir", return_value="/tmp/keys"):
+-                with patch("pathlib.Path.is_dir", return_value=True):
+-                    assert aptpkg.get_repo_keys() == repo_keys_var
+-        else:
+-            assert aptpkg.get_repo_keys() == repo_keys_var
++        with patch("os.listdir", return_value="/tmp/keys"):
++            with patch("pathlib.Path.is_dir", return_value=True):
++                assert aptpkg.get_repo_keys() == repo_keys_var
+ 
+ 
+ def test_file_dict(lowpkg_files_var):
+@@ -973,45 +934,30 @@ def test_mod_repo_match(tmp_path):
+         aptpkg.__salt__,
+         {"config.option": MagicMock(), "no_proxy": MagicMock(return_value=False)},
+     ):
+-        with patch("salt.modules.aptpkg.refresh_db", MagicMock(return_value={})):
+-            with patch("salt.utils.data.is_true", MagicMock(return_value=True)):
+-                with patch("salt.modules.aptpkg.SourceEntry", MagicMock(), create=True):
+-                    with patch(
+-                        "salt.modules.aptpkg.SourcesList",
+-                        MagicMock(return_value=mock_source_list),
+-                        create=True,
+-                    ):
+-                        with patch(
+-                            "salt.modules.aptpkg._split_repo_str",
+-                            MagicMock(
+-                                return_value=(
+-                                    "deb",
+-                                    [],
+-                                    "http://cdn-aws.deb.debian.org/debian/",
+-                                    "stretch",
+-                                    ["main"],
+-                                    "",
+-                                )
+-                            ),
+-                        ):
+-                            source_line_no_slash = (
+-                                "deb http://cdn-aws.deb.debian.org/debian"
+-                                " stretch main"
+-                            )
+-                            if salt.utils.path.which("apt-key"):
+-                                repo = aptpkg.mod_repo(
+-                                    source_line_no_slash, file=file, enabled=False
+-                                )
+-                                assert repo[source_line_no_slash]["uri"] == source_uri
+-                            else:
+-                                with pytest.raises(Exception) as err:
+-                                    repo = aptpkg.mod_repo(
+-                                        source_line_no_slash, file=file, enabled=False
+-                                    )
+-                                assert (
+-                                    "missing 'signedby' option when apt-key is missing"
+-                                    in str(err.value)
+-                                )
++        with patch("salt.modules.aptpkg.refresh_db", MagicMock(return_value={})), patch(
++            "salt.utils.data.is_true", MagicMock(return_value=True)
++        ), patch("salt.modules.aptpkg.SourceEntry", MagicMock(), create=True), patch(
++            "salt.modules.aptpkg.SourcesList",
++            MagicMock(return_value=mock_source_list),
++            create=True,
++        ), patch(
++            "salt.modules.aptpkg._split_repo_str",
++            MagicMock(
++                return_value={
++                    "type": "deb",
++                    "architectures": [],
++                    "uri": "http://cdn-aws.deb.debian.org/debian/",
++                    "dist": "stretch",
++                    "comps": ["main"],
++                    "signedby": "",
++                }
++            ),
++        ):
++            source_line_no_slash = (
++                "deb http://cdn-aws.deb.debian.org/debian stretch main"
++            )
++            repo = aptpkg.mod_repo(source_line_no_slash, enabled=False)
++            assert repo[source_line_no_slash]["uri"] == source_uri
+ 
+ 
+ def test_list_downloaded():
+@@ -1134,7 +1080,7 @@ def test__parse_source(case):
+     importlib.reload(aptpkg)
+ 
+     source = NoAptSourceEntry(case["line"])
+-    ok = source._parse_sources(case["line"])
++    ok = source.parse(case["line"])
+ 
+     assert ok is case["ok"]
+     assert source.invalid is case["invalid"]
+@@ -1280,7 +1226,7 @@ def test_expand_repo_def_cdrom():
+ 
+     # Valid source
+     repo = "# deb cdrom:[Debian GNU/Linux 11.4.0 _Bullseye_ - Official amd64 NETINST 20220709-10:31]/ bullseye main\n"
+-    sanitized = aptpkg.expand_repo_def(os_name="debian", repo=repo, file=source_file)
++    sanitized = aptpkg._expand_repo_def(os_name="debian", repo=repo, file=source_file)
+     log.warning("SAN: %s", sanitized)
+ 
+     assert isinstance(sanitized, dict)
+@@ -1291,7 +1237,7 @@ def test_expand_repo_def_cdrom():
+ 
+     # Pass the architecture and make sure it is added the the line attribute
+     repo = "deb http://cdn-aws.deb.debian.org/debian/ stretch main\n"
+-    sanitized = aptpkg.expand_repo_def(
++    sanitized = aptpkg._expand_repo_def(
+         os_name="debian", repo=repo, file=source_file, architectures="amd64"
+     )
+ 
+@@ -1545,28 +1491,22 @@ SERVICE:cups-daemon,390,/usr/sbin/cupsd
+         ]
+ 
+ 
+-@pytest.mark.skipif(
+-    HAS_APTSOURCES is True, reason="Only run test with python3-apt library is missing."
+-)
+ def test_sourceslist_multiple_comps():
+     """
+     Test SourcesList when repo has multiple comps
+     """
+     repo_line = "deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted"
+-    with patch.object(aptpkg, "HAS_APT", return_value=True):
+-        with patch("salt.utils.files.fopen", mock_open(read_data=repo_line)):
+-            with patch("pathlib.Path.is_file", side_effect=[True, False]):
+-                sources = aptpkg.SourcesList()
+-                for source in sources:
+-                    assert source.type == "deb"
+-                    assert source.uri == "http://archive.ubuntu.com/ubuntu/"
+-                    assert source.comps == ["main", "restricted"]
+-                    assert source.dist == "focal-updates"
++    with patch("salt.utils.files.fopen", mock_open(read_data=repo_line)), patch(
++        "pathlib.Path.is_file", side_effect=[True, False]
++    ):
++        sources = aptpkg.SourcesList()
++        for source in sources:
++            assert source.type == "deb"
++            assert source.uri == "http://archive.ubuntu.com/ubuntu/"
++            assert source.comps == ["main", "restricted"]
++            assert source.dist == "focal-updates"
+ 
+ 
+-@pytest.mark.skipif(
+-    HAS_APTSOURCES is True, reason="Only run test with python3-apt library is missing."
+-)
+ @pytest.mark.parametrize(
+     "repo_line",
+     [
+-- 
+2.52.0
+


### PR DESCRIPTION
pytest-subtests has been subsumed into pytest as of version 9, as such, the Python maintainers would like to remove it from Factory, so drop the Requires, guarded by a version check.