### PR TITLE
Fix apacheclt detection, ldap module, and stabilize testsuite

### DIFF
--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -670,6 +670,8 @@ Patch213:       fix-the-default-group-in-tests-for-new-users-in-sle-.patch
 Patch214:       fix-the-tests-failing-after-switching-to-non-vendore.patch
 # PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/68650
 Patch215:       support-attrlist-in-ldap.managed-746.patch
+# PATCH-FIX_UPSTREAM: https://github.com/salt-extensions/saltext-apache/pull/14
+Patch216:       switch-apache2ctl-to-apachectl-for-suse-oses-bsc-125.patch
 
 ### IMPORTANT: The line below is used as a snippet marker. Do not touch it.
 ### SALT PATCHES LIST END

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -668,6 +668,8 @@ Patch213:       fix-the-default-group-in-tests-for-new-users-in-sle-.patch
 # PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/commit/dfe321bc1564fbaa7b6a19ff0f78a05cae45d3d0
 # PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/commit/e8c016419b73aaefab32880fe91ad694f0c6668e
 Patch214:       fix-the-tests-failing-after-switching-to-non-vendore.patch
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/pull/68650
+Patch215:       support-attrlist-in-ldap.managed-746.patch
 
 ### IMPORTANT: The line below is used as a snippet marker. Do not touch it.
 ### SALT PATCHES LIST END

--- a/salt/salt.spec
+++ b/salt/salt.spec
@@ -672,6 +672,8 @@ Patch214:       fix-the-tests-failing-after-switching-to-non-vendore.patch
 Patch215:       support-attrlist-in-ldap.managed-746.patch
 # PATCH-FIX_UPSTREAM: https://github.com/salt-extensions/saltext-apache/pull/14
 Patch216:       switch-apache2ctl-to-apachectl-for-suse-oses-bsc-125.patch
+# PATCH-FIX_UPSTREAM: https://github.com/saltstack/salt/commit/4c4d017ddb45e4e689d978ae1deb975ad7a4c220
+Patch217:       stabilize-testsuite-tests-and-fix-alleventshandler-7.patch
 
 ### IMPORTANT: The line below is used as a snippet marker. Do not touch it.
 ### SALT PATCHES LIST END

--- a/salt/stabilize-testsuite-tests-and-fix-alleventshandler-7.patch
+++ b/salt/stabilize-testsuite-tests-and-fix-alleventshandler-7.patch
@@ -1,0 +1,106 @@
+From b3cfcc374b8ec706cea002f6dd48dbbb380fdb9b Mon Sep 17 00:00:00 2001
+From: Marek Czernek <marek.czernek@suse.com>
+Date: Wed, 15 Jul 2026 15:55:21 +0200
+Subject: [PATCH] Stabilize testsuite tests and fix AllEventsHandler (#770)
+
+In AllEventsHandler, new Tornado uses async method for
+tornado.websocket.WebSocketHandler:get, which means
+calls to ws://IP:PORT/all_events/ are broken with
+Tornados >= 6. Consequently, AllEventsHandler:get
+now uses tornado.gen.coroutine to work on old and
+new Tornado versions.
+
+Changes to test_utils.py and test_webhooks_handler.py
+are partial cherrypick of:
+- https://github.com/saltstack/salt/commit/4c4d017ddb45e4e689d978ae1deb975ad7a4c220
+---
+ .../rest_tornado/saltnado_websockets.py       |  3 ++-
+ .../netapi/rest_tornado/test_utils.py         |  2 ++
+ .../rest_tornado/test_webhooks_handler.py     | 21 ++++++++++++-------
+ 3 files changed, 18 insertions(+), 8 deletions(-)
+
+diff --git a/salt/netapi/rest_tornado/saltnado_websockets.py b/salt/netapi/rest_tornado/saltnado_websockets.py
+index 98d64000909..74cc3f89ed4 100644
+--- a/salt/netapi/rest_tornado/saltnado_websockets.py
++++ b/salt/netapi/rest_tornado/saltnado_websockets.py
+@@ -313,6 +313,7 @@ class AllEventsHandler(
+     """
+ 
+     # pylint: disable=W0221
++    @tornado.gen.coroutine
+     def get(self, token):
+         """
+         Check the token, returns a 401 if the token is invalid.
+@@ -326,7 +327,7 @@ class AllEventsHandler(
+             log.debug("Refusing websocket connection, bad token!")
+             self.send_error(401)
+             return
+-        super().get(token)
++        yield super().get(token)
+ 
+     def open(self, token):  # pylint: disable=W0221
+         """
+diff --git a/tests/pytests/functional/netapi/rest_tornado/test_utils.py b/tests/pytests/functional/netapi/rest_tornado/test_utils.py
+index a32de85de1d..bb725626332 100644
+--- a/tests/pytests/functional/netapi/rest_tornado/test_utils.py
++++ b/tests/pytests/functional/netapi/rest_tornado/test_utils.py
+@@ -20,6 +20,7 @@ async def test_any_future():
+     futures[0].set_result("foo")
+ 
+     await futures[0]
++    await any_
+ 
+     assert any_.done() is True
+     assert futures[0].done() is True
+@@ -34,6 +35,7 @@ async def test_any_future():
+     any_ = saltnado.Any(futures)
+     futures[0].set_result("foo")
+     await futures[0]
++    await any_
+ 
+     assert any_.done() is True
+     assert futures[0].done() is True
+diff --git a/tests/pytests/functional/netapi/rest_tornado/test_webhooks_handler.py b/tests/pytests/functional/netapi/rest_tornado/test_webhooks_handler.py
+index 3b199b6e209..b87bda110b8 100644
+--- a/tests/pytests/functional/netapi/rest_tornado/test_webhooks_handler.py
++++ b/tests/pytests/functional/netapi/rest_tornado/test_webhooks_handler.py
+@@ -1,6 +1,7 @@
+ import urllib.parse
+ 
+ import pytest
++import tornado
+ 
+ import salt.utils.json
+ from salt.netapi.rest_tornado import saltnado
+@@ -28,15 +29,21 @@ async def test_hook_can_handle_get_parameters(http_client, app, content_type_map
+             )
+             assert response.code == 200
+             host = urllib.parse.urlparse(response.effective_url).netloc
++
++            expected_headers = {
++                "Content-Length": "2",
++                "Connection": "close",
++                "Content-Type": "application/json",
++                "Host": host,
++                "Accept-Encoding": "gzip",
++            }
++
++            if tornado.version_info >= (6,):
++                expected_headers["User-Agent"] = f"Tornado/{tornado.version}"
++
+             event.fire_event.assert_called_once_with(
+                 {
+-                    "headers": {
+-                        "Content-Length": "2",
+-                        "Connection": "close",
+-                        "Content-Type": "application/json",
+-                        "Host": host,
+-                        "Accept-Encoding": "gzip",
+-                    },
++                    "headers": expected_headers,
+                     "post": {},
+                     "get": {"param": ["1", "2"]},
+                 },
+-- 
+2.55.0
+

--- a/salt/support-attrlist-in-ldap.managed-746.patch
+++ b/salt/support-attrlist-in-ldap.managed-746.patch
@@ -1,0 +1,183 @@
+From 7a953241ed4371aac8f8c758a4a45e5143493cf5 Mon Sep 17 00:00:00 2001
+From: Georg <georg.pfuetzenreuter@suse.com>
+Date: Mon, 13 Jul 2026 14:27:50 +0000
+Subject: [PATCH] Support attrlist in ldap.managed (#746)
+
+This resolves not being able to manage operational attributes by
+introducing a way to pass the list to filter in the LDAP search through
+to the search function. Passing a customizable list was deemed most
+flexible, as one might not want to control all but only specific
+operational attributes. For example, one can set attrlist to ["*",
+"aci"] to manage all user attributes plus the "aci" operational
+attribute.
+
+
+(cherry picked from commit 443bcb8473d4c3958c3ad87fba4a31b9e89b07b1)
+
+Signed-off-by: Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>
+---
+ changelog/53364.fixed.md               |  1 +
+ salt/states/ldap.py                    | 14 ++++++++----
+ tests/pytests/unit/states/test_ldap.py | 31 ++++++++++++++++++--------
+ 3 files changed, 33 insertions(+), 13 deletions(-)
+ create mode 100644 changelog/53364.fixed.md
+
+diff --git a/changelog/53364.fixed.md b/changelog/53364.fixed.md
+new file mode 100644
+index 00000000000..91c6a5733d2
+--- /dev/null
++++ b/changelog/53364.fixed.md
+@@ -0,0 +1 @@
++Support attrlist in ldap.managed
+diff --git a/salt/states/ldap.py b/salt/states/ldap.py
+index 227182b828b..16ca1fae189 100644
+--- a/salt/states/ldap.py
++++ b/salt/states/ldap.py
+@@ -19,7 +19,7 @@ from salt.utils.stringutils import to_bytes
+ log = logging.getLogger(__name__)
+ 
+ 
+-def managed(name, entries, connect_spec=None):
++def managed(name, entries, connect_spec=None, attrlist=None):
+     """Ensure the existence (or not) of LDAP entries and their attributes
+ 
+     Example:
+@@ -183,6 +183,12 @@ def managed(name, entries, connect_spec=None):
+         the ``'url'`` entry is set to the value of the ``name``
+         parameter.
+ 
++    :param attrlist:
++        Passed directly to :py:func:`ldap3.connect <salt.modules.ldap3.search>`
++        to filter the attributes returned by the LDAP server. By default, all
++        user attributes will be requested, and this should only need to be
++        modified if management of operational attributes is desired.
++
+     :returns:
+         A dict with the following keys:
+ 
+@@ -254,7 +260,7 @@ def managed(name, entries, connect_spec=None):
+ 
+     with connect(connect_spec) as l:
+ 
+-        old, new = _process_entries(l, entries)
++        old, new = _process_entries(l, attrlist, entries)
+ 
+         # collect all of the affected entries (only the key is
+         # important in this dict; would have used an OrderedSet if
+@@ -366,7 +372,7 @@ def managed(name, entries, connect_spec=None):
+     return ret
+ 
+ 
+-def _process_entries(l, entries):
++def _process_entries(l, attrlist, entries):
+     """Helper for managed() to process entries and return before/after views
+ 
+     Collect the current database state and update it according to the
+@@ -419,7 +425,7 @@ def _process_entries(l, entries):
+             olde = new.get(dn, None)
+             if olde is None:
+                 # next check the database
+-                results = __salt__["ldap3.search"](l, dn, "base")
++                results = __salt__["ldap3.search"](l, dn, "base", attrlist=attrlist)
+                 if len(results) == 1:
+                     attrs = results[dn]
+                     olde = {
+diff --git a/tests/pytests/unit/states/test_ldap.py b/tests/pytests/unit/states/test_ldap.py
+index bf57549fd9c..f8c8d41cd24 100644
+--- a/tests/pytests/unit/states/test_ldap.py
++++ b/tests/pytests/unit/states/test_ldap.py
+@@ -29,7 +29,7 @@ class LdapDB:
+     def dummy_connect(self, connect_spec):
+         return _dummy_ctx()
+ 
+-    def dummy_search(self, connect_spec, base, scope):
++    def dummy_search(self, connect_spec, base, scope, attrlist):
+         if base not in self.db:
+             return {}
+         return {
+@@ -37,6 +37,7 @@ class LdapDB:
+                 attr: list(self.db[base][attr])
+                 for attr in self.db[base]
+                 if len(self.db[base][attr])
++                and (attrlist is None or attr in attrlist or "*" in attrlist)
+             }
+         }
+ 
+@@ -199,7 +200,7 @@ def configure_loader_modules(db):
+     return {salt.states.ldap: {"__opts__": {"test": False}, "__salt__": salt_dunder}}
+ 
+ 
+-def _test_helper(init_db, expected_ret, replace, delete_others=False):
++def _test_helper(init_db, expected_ret, replace, delete_others=False, attrlist=None):
+     old = init_db.dump_db()
+     new = init_db.dump_db()
+     expected_db = copy.deepcopy(init_db.db)
+@@ -262,13 +263,13 @@ def _test_helper(init_db, expected_ret, replace, delete_others=False):
+         {dn: [{"replace": attrs}, {"delete_others": delete_others}]}
+         for dn, attrs in replace.items()
+     ]
+-    actual = salt.states.ldap.managed(name, entries)
++    actual = salt.states.ldap.managed(name, entries, attrlist=attrlist)
+     assert expected_ret == actual
+     assert expected_db == init_db.db
+ 
+ 
+-def _test_helper_success(db, replace, delete_others=False):
+-    _test_helper(db, {}, replace, delete_others)
++def _test_helper_success(db, replace, delete_others=False, attrlist=None):
++    _test_helper(db, {}, replace, delete_others, attrlist)
+ 
+ 
+ def _test_helper_nochange(db, replace, delete_others=False):
+@@ -279,7 +280,7 @@ def _test_helper_nochange(db, replace, delete_others=False):
+     _test_helper(db, expected, replace, delete_others)
+ 
+ 
+-def _test_helper_add(db, expected_ret, add_items, delete_others=False):
++def _test_helper_add(db, expected_ret, add_items, delete_others=False, attrlist=None):
+     old = db.dump_db()
+     new = db.dump_db()
+     expected_db = copy.deepcopy(db.db)
+@@ -346,13 +347,13 @@ def _test_helper_add(db, expected_ret, add_items, delete_others=False):
+         {dn: [{"add": attrs}, {"delete_others": delete_others}]}
+         for dn, attrs in add_items.items()
+     ]
+-    actual = salt.states.ldap.managed(name, entries)
++    actual = salt.states.ldap.managed(name, entries, attrlist=attrlist)
+     assert expected_ret == actual
+     assert expected_db == db.db
+ 
+ 
+-def _test_helper_success_add(db, add_items, delete_others=False):
+-    _test_helper_add(db, {}, add_items, delete_others)
++def _test_helper_success_add(db, add_items, delete_others=False, attrlist=None):
++    _test_helper_add(db, {}, add_items, delete_others, attrlist)
+ 
+ 
+ def test_managed_empty(db):
+@@ -374,10 +375,22 @@ def test_managed_add_entry(db):
+ def test_managed_add_attr(complex_db):
+     _test_helper_success_add(complex_db, {"dnfoo": {"attrfoo1": ["valfoo1.3"]}})
+     _test_helper_success_add(complex_db, {"dnfoo": {"attrfoo4": ["valfoo4.1"]}})
++    _test_helper_success_add(
++        complex_db, {"dnfoo": {"attrfoo10": ["valfoo10"]}}, attrlist=["*"]
++    )
++    _test_helper_success_add(
++        complex_db, {"dnfoo11": {"attrfoo11": ["valfoo11"]}}, attrlist=["attrfoo11"]
++    )
+ 
+ 
+ def test_managed_replace_attr(complex_db):
+     _test_helper_success(complex_db, {"dnfoo": {"attrfoo3": ["valfoo3.1"]}})
++    _test_helper_success(
++        complex_db, {"dnfoo": {"attrfoo12": ["valfoo12"]}}, attrlist=["*"]
++    )
++    _test_helper_success(
++        complex_db, {"dnfoo13": {"attrfoo13": ["valfoo13"]}}, attrlist=["attrfoo13"]
++    )
+ 
+ 
+ def test_managed_simplereplace(complex_db):
+-- 
+2.55.0
+

--- a/salt/switch-apache2ctl-to-apachectl-for-suse-oses-bsc-125.patch
+++ b/salt/switch-apache2ctl-to-apachectl-for-suse-oses-bsc-125.patch
@@ -1,0 +1,40 @@
+From fa61d25e275c7549cb3097db60d6edf79ab5781a Mon Sep 17 00:00:00 2001
+From: Marek Czernek <marek.czernek@suse.com>
+Date: Wed, 15 Jul 2026 15:54:50 +0200
+Subject: [PATCH] Switch apache2ctl to apachectl for SUSE OSes
+ (bsc#1252286) (#771)
+
+---
+ salt/modules/apache.py      | 2 +-
+ salt/modules/suse_apache.py | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/salt/modules/apache.py b/salt/modules/apache.py
+index 4b867706d10..b3a8c05e1be 100644
+--- a/salt/modules/apache.py
++++ b/salt/modules/apache.py
+@@ -45,7 +45,7 @@ def _detect_os():
+     os_family = __grains__["os_family"]
+     if os_family == "RedHat":
+         return "apachectl"
+-    elif os_family == "Debian" or os_family == "Suse":
++    elif os_family == "Debian":
+         return "apache2ctl"
+     else:
+         return "apachectl"
+diff --git a/salt/modules/suse_apache.py b/salt/modules/suse_apache.py
+index 7c599b34a83..fc0899bfe86 100644
+--- a/salt/modules/suse_apache.py
++++ b/salt/modules/suse_apache.py
+@@ -19,7 +19,7 @@ def __virtual__():
+     """
+     Only load the module if apache is installed.
+     """
+-    if salt.utils.path.which("apache2ctl") and __grains__["os_family"] == "Suse":
++    if salt.utils.path.which("apachectl") and __grains__["os_family"] == "Suse":
+         return __virtualname__
+     return (False, "apache execution module not loaded: apache not installed.")
+ 
+-- 
+2.55.0
+


### PR DESCRIPTION
This PR ports the following commits:

- Support attrlist in ldap.managed - https://github.com/openSUSE/salt/pull/746
- Switch apache2ctl to apachectl for SUSE OSes - github.com/openSUSE/salt/pull/771
- Stabilize testsuite tests and fix AllEventsHandler - https://github.com/openSUSE/salt/pull/770